### PR TITLE
Add the generated family footer

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -353,3 +353,13 @@ Epic レーン（`E-1`〜`E-10`）は任意です。オーナーが承認して�
 **ドキュメントのみ** ｜ **ランタイム不要** ｜ **git と Issue / PR だけで動く**
 
 </div>
+
+<!-- family:generated:family-footer:start -->
+
+---
+
+このリポジトリは **Caty AI ファミリー** の一員です — AI エージェントの家族を運用するためのオープンなツール群。公開準備中のモジュールを含む全体の地図は [Family OS](https://github.com/caty-ai/family-os) にあります。
+
+兄弟モジュール: [Caty Agent Harness](https://github.com/caty-ai/caty-agent-harness) · [Persona Engine](https://github.com/caty-ai/persona-engine) · [Sitter](https://github.com/caty-ai/sitter) · [X Collector](https://github.com/caty-ai/x-collector)
+
+<!-- family:generated:family-footer:end -->

--- a/README.md
+++ b/README.md
@@ -357,3 +357,13 @@ The documents under `docs/` are written in Japanese, and this English README is 
 **Docs only** ｜ **No runtime** ｜ **Runs on git and Issues / PRs alone**
 
 </div>
+
+<!-- family:generated:family-footer:start -->
+
+---
+
+Part of the **Caty AI family** — open tools for running a family of AI agents. The full map, including modules still being prepared for release, lives in [Family OS](https://github.com/caty-ai/family-os).
+
+Siblings: [Caty Agent Harness](https://github.com/caty-ai/caty-agent-harness) · [Persona Engine](https://github.com/caty-ai/persona-engine) · [Sitter](https://github.com/caty-ai/sitter) · [X Collector](https://github.com/caty-ai/x-collector)
+
+<!-- family:generated:family-footer:end -->

--- a/README.th.md
+++ b/README.th.md
@@ -357,3 +357,13 @@ flowchart TD
 **เอกสารล้วน** ｜ **ไม่ต้องมีรันไทม์** ｜ **ทำงานได้ด้วย git กับ Issue / PR เท่านั้น**
 
 </div>
+
+<!-- family:generated:family-footer:start -->
+
+---
+
+รีโพนี้เป็นส่วนหนึ่งของ **ครอบครัว Caty AI** — ชุดเครื่องมือโอเพนซอร์สสำหรับดูแลครอบครัวเอเจนต์ AI แผนที่ฉบับเต็ม (รวมโมดูลที่กำลังเตรียมเปิด) อยู่ที่ [Family OS](https://github.com/caty-ai/family-os)
+
+โมดูลพี่น้อง: [Caty Agent Harness](https://github.com/caty-ai/caty-agent-harness) · [Persona Engine](https://github.com/caty-ai/persona-engine) · [Sitter](https://github.com/caty-ai/sitter) · [X Collector](https://github.com/caty-ai/x-collector)
+
+<!-- family:generated:family-footer:end -->

--- a/README.zh.md
+++ b/README.zh.md
@@ -357,3 +357,13 @@ Epic 车道（`E-1`–`E-10`）是可选的。只有在负责人批准之后才�
 **只有文档** ｜ **无需运行时** ｜ **只靠 git 和 Issue / PR 就能运转**
 
 </div>
+
+<!-- family:generated:family-footer:start -->
+
+---
+
+本仓库属于 **Caty AI 家族** — 用于运营 AI 智能体家族的开源工具集。完整地图（包括仍在准备公开的模块）见 [Family OS](https://github.com/caty-ai/family-os)。
+
+同家族模块: [Caty Agent Harness](https://github.com/caty-ai/caty-agent-harness) · [Persona Engine](https://github.com/caty-ai/persona-engine) · [Sitter](https://github.com/caty-ai/sitter) · [X Collector](https://github.com/caty-ai/x-collector)
+
+<!-- family:generated:family-footer:end -->


### PR DESCRIPTION
Mechanical rollout child of caty-ai/family-os#5 (design frozen after three independent review rounds; generator and checks landed in caty-ai/family-os#6).

Adds the generated family footer to all four README language files: one line saying this repository is part of the Caty AI family with a link to the map, plus links to the published sibling modules. Preparing modules are deliberately not linked here — the map owns that list, so this footer never ships an intentional 404.

The region between the markers is machine-maintained and verified byte-exact by family-os's weekly check once the registry flag flips (the epic's final child). To change the footer, edit `registry/modules.json` in family-os and re-render — not this file.

Generated output; no hand-written content beyond this description.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
