### PR TITLE
ci: risk reviewer roster (PR-A of #25)

### DIFF
--- a/.github/risk-reviewers.txt
+++ b/.github/risk-reviewers.txt
@@ -1,0 +1,11 @@
+# .github/risk-reviewers.txt — 高リスク確認者名簿 (1行 = 1 GitHub ID)
+#
+# 使い方: このファイルを対象リポの .github/risk-reviewers.txt にコピーして commit する。
+# - Risk Review Gate は名簿を base (main) 側から読む。PR 側で名簿を書き換えても効かない
+#   (「PR が名簿に自分を足して自分で通す」循環の封じ)。名簿の変更自体が高リスクパスとして
+#   人間確認の対象になる。
+# - REPLACE_ME を実際のオーナー (人間) の GitHub ID に置き換えること。
+#   プレースホルダのまま・空のままなら gate は赤 (fail-closed)。
+# - 秘密ではないのでリポ変数や環境変数に置かない (handbook docs/09 R-3② — 非秘密の設定は
+#   コミットされたファイルへ。変更が PR に現れて可視になる)。
+shojikumaru


### PR DESCRIPTION
#25 の PR-A（2段構成の先行便）。名簿は Risk Review Gate が base=main 側から読むため、workflows 一式（PR-B）より先に単独で merge する。中身はオーナー（人間）ID 1行=shojikumaru。

- Files: .github/risk-reviewers.txt のみ
- 参照: templates/ci/README.md 手順2 / Issue #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)