### PR TITLE
ci(templates): v0.9.2 — RISK_PATHS_AUTH 常設カテゴリ・none 大小文字硬化・死にパターン警告・README 落とし穴3点 (#30 #31 #32)

### DIFF
--- a/templates/ci/README.md
+++ b/templates/ci/README.md
@@ -28,7 +28,7 @@
 4. `# CUSTOMIZE` を埋める:
    - `test-lint.yml` — テスト/lint コマンド（**未設定のままだと赤で落ち続ける = 仕様**）
    - `pr-size.yml` — サイズ計測の除外パターン
-   - `review-labels.yml` — **高リスク領域のリポ固有パスをカテゴリ別に宣言（`RISK_PATHS_BILLING` = 課金・支出 / `RISK_PATHS_OUTBOUND` = 対外公開・対人送信 / `RISK_PATHS_GATES` = 門番の実体＝test/lint が呼ぶリポ固有スクリプト・設定）。「該当なし」でもカテゴリごとに `none` の明示宣言まで必須**（いずれかが `__DECLARE_ME__` のままなら赤）
+   - `review-labels.yml` — **高リスク領域のリポ固有パスをカテゴリ別に宣言（`RISK_PATHS_BILLING` = 課金・支出 / `RISK_PATHS_OUTBOUND` = 対外公開・対人送信 / `RISK_PATHS_GATES` = 門番の実体＝test/lint が呼ぶリポ固有スクリプト・設定 / `RISK_PATHS_AUTH` = 認証・権限境界）。「該当なし」でもカテゴリごとに `none` の明示宣言まで必須**（いずれかが `__DECLARE_ME__` のままなら赤）。AUTH は既定網の `**/auth/**` が「認証コードは auth/ ディレクトリにある」配置前提のため常設 — フラット配置（`app/auth.py` 等）のリポは実パスを列挙し、auth/ 配下に集約済みのリポだけ `none` と書く
 5. branch protection の required status checks に各門番の check 名（`test` / `lint` / `gitleaks` / `history-check` / `risk-review-gate`）を登録する。**`pr-size` は既定で required に含めない**（可視化ゲート・required 化は各リポの判断）
 6. **`check-required-checks.sh` を実行して登録を機械確認する**:
    ```bash
@@ -43,12 +43,15 @@
 | `test-lint.yml` | `# CUSTOMIZE` ×2（test / lint コマンド） | `make test` / `make lint`（Makefile 不在 = 赤） |
 | `gitleaks.yml` | なし（バージョン pin + SHA256 は型の固定値・更新は handbook 改訂で） | gitleaks v8.30.1 |
 | `pr-size.yml` | 除外パターン / `MAX_LINES` | lockfile・`i18n/**` 除外 / 250 行 |
-| `review-labels.yml` | `RISK_PATHS_BILLING` / `RISK_PATHS_OUTBOUND` / `RISK_PATHS_GATES`（カテゴリ別・宣言必須） | 各 `__DECLARE_ME__`（= 赤） |
+| `review-labels.yml` | `RISK_PATHS_BILLING` / `RISK_PATHS_OUTBOUND` / `RISK_PATHS_GATES` / `RISK_PATHS_AUTH`（カテゴリ別・宣言必須） | 各 `__DECLARE_ME__`（= 赤） |
 | `check-required-checks.sh` | `EXPECTED`（required に登録した check 名） | 5 門番（pr-size 除く） |
 
 ## 落とし穴
 
 - **required checks 未登録** — 門番は赤を出すが merge は止まらない。手順 6 の機械確認まで終えて「展開済み」
+- **展開検証のダミー secret に bare な AWS access key ID（AKIA+16桁）を使わない** — gitleaks v8.30.1 の既定ルールでは access key ID 単体は検知されず、「門番が壊れている」ように見える偽陰性になる。検知確認済みフィクスチャ（例: 切り詰めた PEM 秘密鍵ブロック）を使う。仕込みはサーバーサイドコミット（contents API）推奨 — ローカルの secret 検知フックと手元 commit がデッドロックするため
+- **test/lint の充て先は「対象0件で緑」にならない形に** — 対象を数えて0件なら赤（型の Makefile 例は非空ガード焼き込み済み。`# CUSTOMIZE` でコマンドを差し替える時もこの性質を保つ — 対象 glob が空振りすると「全部通った」と「何も検査していない」が同じ緑になる）
+- **シェルスクリプトの lint 充て先は `*.sh` glob だけにしない** — 拡張子なし（shebang のみ）のスクリプトが漏れる。shebang スキャン（例: `grep -rl '^#!.*sh' --exclude-dir=.git`）を併用して対象を組み立てる
 - **fetch-depth** — 履歴を使う門番（gitleaks / pr-size / history-check / review-labels）は `fetch-depth: 0` が必須（型に焼き込み済み・浅くすると「diff 解決不能 → 緑」の fail-open になる）
 - **fork PR** — ゲート判定（read）は fork でも必ず走って赤/緑を出す。承認・免除は**作者が単独で起こせるイベント（synchronize / reopened / ready_for_review、pr-size は edited も）の run では常に無効**で、緑に戻せるのは triage 権限者しか起こせないイベント（labeled / unlabeled）だけ — 作者単独の承認持ち回しは fork でも成立しない。ラベル付与・剥がし（write）は 403 で警告になる（可視化の劣化のみ）。**残余**: 剥がせない古いラベルが triage 権限者の別ラベル操作（labeled / unlabeled の run）で再び有効に見える経路は残る — 共有クレデンシャル環境ではこの線引き自体が identity 分離（機械的保証の前提）待ちであり、このゲートの「可視化+監査」位置づけの範囲内。厳密な SHA 束縛が要る場合は方式2（タイムライン3条件 AND）へ
 - **`pull_request_target` は使わない** — untrusted コードに write トークンを渡す典型的脆弱形（全門番 `pull_request` トリガ）

--- a/templates/ci/README.md
+++ b/templates/ci/README.md
@@ -28,13 +28,13 @@
 4. `# CUSTOMIZE` を埋める:
    - `test-lint.yml` — テスト/lint コマンド（**未設定のままだと赤で落ち続ける = 仕様**）
    - `pr-size.yml` — サイズ計測の除外パターン
-   - `review-labels.yml` — **高リスク領域のリポ固有パスをカテゴリ別に宣言（`RISK_PATHS_BILLING` = 課金・支出 / `RISK_PATHS_OUTBOUND` = 対外公開・対人送信 / `RISK_PATHS_GATES` = 門番の実体＝test/lint が呼ぶリポ固有スクリプト・設定 / `RISK_PATHS_AUTH` = 認証・権限境界）。「該当なし」でもカテゴリごとに `none` の明示宣言まで必須**（いずれかが `__DECLARE_ME__` のままなら赤）。AUTH は既定網の `**/auth/**` が「認証コードは auth/ ディレクトリにある」配置前提のため常設 — フラット配置（`app/auth.py` 等）のリポは実パスを列挙し、auth/ 配下に集約済みのリポだけ `none` と書く
+   - `review-labels.yml` — **高リスク領域のリポ固有パスをカテゴリ別に宣言（`RISK_PATHS_BILLING` = 課金・支出 / `RISK_PATHS_OUTBOUND` = 対外公開・対人送信 / `RISK_PATHS_GATES` = 門番の実体＝test/lint が呼ぶリポ固有スクリプト・設定 / `RISK_PATHS_AUTH` = 認証・権限境界）。「該当なし」でもカテゴリごとに `none` の明示宣言まで必須**（いずれかが `__DECLARE_ME__` のままなら赤）。AUTH は既定網の `**/auth/**` が「認証コードは auth/ ディレクトリにある」配置前提のため常設 — フラット配置（`app/auth.py` 等）のリポは実パスを列挙し、auth/ 配下に集約済みのリポだけ `none` と書く（AUTH=none で `**/auth/**` が0マッチのリポには検知ログが警告を出す）。**複数パターンは1行1パターンの改行区切り**（空白区切りで1行に並べると「空白を含む1つの pathspec」＝0件マッチになるため、行内空白は赤で止まる）。「該当なし」の受理語は `none` のみ（大小文字不問・`n/a` 等の同義語は不可）
 5. branch protection の required status checks に各門番の check 名（`test` / `lint` / `gitleaks` / `history-check` / `risk-review-gate`）を登録する。**`pr-size` は既定で required に含めない**（可視化ゲート・required 化は各リポの判断）
 6. **`check-required-checks.sh` を実行して登録を機械確認する**:
    ```bash
    bash check-required-checks.sh <owner/repo> main
    ```
-   登録確認を README のお願いで終わらせない（R-6 の自己適用）。branch protection が張れない環境（private の無償プラン等）は、その旨を導入台帳に明示記録する（FP-5: 劣化の可視化）
+   登録確認を README のお願いで終わらせない（R-6 の自己適用）。branch protection が張れない環境（private の無償プラン等）は、その旨を導入台帳に明示記録する（FP-5: 劣化の可視化）。あわせて **detect-risk-paths ジョブのログに死にパターンの `::warning::` が出ていないことを確認する**（警告は「緑だが守れていない可能性」の唯一のシグナル — 出ていたら宣言を直してから「展開済み」）
 
 ## カスタマイズ早見表
 
@@ -50,8 +50,10 @@
 
 - **required checks 未登録** — 門番は赤を出すが merge は止まらない。手順 6 の機械確認まで終えて「展開済み」
 - **展開検証のダミー secret に bare な AWS access key ID（AKIA+16桁）を使わない** — gitleaks v8.30.1 の既定ルールでは access key ID 単体は検知されず、「門番が壊れている」ように見える偽陰性になる。検知確認済みフィクスチャ（例: 切り詰めた PEM 秘密鍵ブロック）を使う。仕込みはサーバーサイドコミット（contents API）推奨 — ローカルの secret 検知フックと手元 commit がデッドロックするため
-- **test/lint の充て先は「対象0件で緑」にならない形に** — 対象を数えて0件なら赤（型の Makefile 例は非空ガード焼き込み済み。`# CUSTOMIZE` でコマンドを差し替える時もこの性質を保つ — 対象 glob が空振りすると「全部通った」と「何も検査していない」が同じ緑になる）
+- **test/lint の充て先は「対象0件で緑」にならない形に** — 対象を数えて0件なら赤にする（導入例: 本リポ自身の Makefile は対象ファイルの非空ガード込み）。`# CUSTOMIZE` でコマンドを差し替える時もこの性質を保つ — 対象 glob が空振りすると「全部通った」と「何も検査していない」が同じ緑になる
 - **シェルスクリプトの lint 充て先は `*.sh` glob だけにしない** — 拡張子なし（shebang のみ）のスクリプトが漏れる。shebang スキャン（例: `grep -rl '^#!.*sh' --exclude-dir=.git`）を併用して対象を組み立てる
+- **死にパターン警告は「緑だが守れていない」の唯一のシグナル** — 宣言パターンが HEAD の1ファイルにも解決しない時、detect-risk-paths ログに `::warning::` が出る（LC-5: 検知は機械・判断は人間 — check は赤にならない）。展開時（手順 6）と、リネーム・配置変更を含む PR のマージ時に確認し、出ていたら宣言を追随させる
+- **v0.9.2 で `RISK_PATHS_AUTH` が増えた（第4常設カテゴリ）** — v0.9.1 以前の展開済みリポにテンプレを再コピーすると、AUTH を宣言するまで全 PR が赤になる（仕様・fail-closed）。更新 PR に AUTH 宣言（実パス列挙 or `none`）を必ず同梱する
 - **fetch-depth** — 履歴を使う門番（gitleaks / pr-size / history-check / review-labels）は `fetch-depth: 0` が必須（型に焼き込み済み・浅くすると「diff 解決不能 → 緑」の fail-open になる）
 - **fork PR** — ゲート判定（read）は fork でも必ず走って赤/緑を出す。承認・免除は**作者が単独で起こせるイベント（synchronize / reopened / ready_for_review、pr-size は edited も）の run では常に無効**で、緑に戻せるのは triage 権限者しか起こせないイベント（labeled / unlabeled）だけ — 作者単独の承認持ち回しは fork でも成立しない。ラベル付与・剥がし（write）は 403 で警告になる（可視化の劣化のみ）。**残余**: 剥がせない古いラベルが triage 権限者の別ラベル操作（labeled / unlabeled の run）で再び有効に見える経路は残る — 共有クレデンシャル環境ではこの線引き自体が identity 分離（機械的保証の前提）待ちであり、このゲートの「可視化+監査」位置づけの範囲内。厳密な SHA 束縛が要る場合は方式2（タイムライン3条件 AND）へ
 - **`pull_request_target` は使わない** — untrusted コードに write トークンを渡す典型的脆弱形（全門番 `pull_request` トリガ）

--- a/templates/ci/review-labels.yml
+++ b/templates/ci/review-labels.yml
@@ -89,29 +89,50 @@ jobs:
           # 1ファイル PR で無力化する経路 (make test を true 化等) を人間確認の対象に入れる
           # (handbook#28・icase 照合なので makefile 等の大小変種も **/Makefile が拾う)。
           # CUSTOMIZE (宣言必須・カテゴリ別): このリポ固有のパスをカテゴリごとに列挙する。
-          # 該当が無いカテゴリは none と明示宣言する。どちらか一方でも __DECLARE_ME__ のまま
-          # (宣言なし) なら赤 — 「書き忘れたカテゴリだけ静かに fail-open」をカテゴリ単位で
-          # 許さない (fail-closed)。
+          # 該当が無いカテゴリは none と明示宣言する (大小文字は問わない)。どれか一つでも
+          # __DECLARE_ME__ のまま (宣言なし) なら赤 — 「書き忘れたカテゴリだけ静かに fail-open」を
+          # カテゴリ単位で許さない (fail-closed)。
           RISK_PATHS_BILLING='__DECLARE_ME__'   # 課金・支出 (例: **/billing/**) — 該当なしなら none
           RISK_PATHS_OUTBOUND='__DECLARE_ME__'  # 対外公開・対人送信 (例: **/publish/**) — 該当なしなら none
           RISK_PATHS_GATES='__DECLARE_ME__'     # 門番の実体 (test/lint が呼ぶリポ固有スクリプト・設定。例: scripts/readme-check/**) — DEFAULT の Makefile/scripts/ci/** で足りるなら none
+          # AUTH が DEFAULT に **/auth/** を持ちながら常設カテゴリでもある理由 (#31): その glob は
+          # 「認証コードは auth/ ディレクトリにある」という配置前提で、フラット配置 (app/auth.py・
+          # app/apple_signin.py 等) のリポでは 0 ファイルにマッチし、認証高リスク面がまるごと網外に
+          # なる。配置前提を型に埋めず、リポごとの明示宣言 (fail-closed) に乗せる。
+          RISK_PATHS_AUTH='__DECLARE_ME__'      # 認証・権限境界 (例: app/auth*.py **/token*.py) — 認証コードが auth/ ディレクトリ配下に集約済み (DEFAULT の **/auth/** が実ファイルを拾う) なら none
 
           RISK_PATHS_REPO=''
           check_category() {
             NAME="$1"; VAL="$2"
             STRIPPED="$(echo "${VAL}" | tr -d '[:space:]')"
+            # none / プレースホルダの照合は小文字化してから — 'None' 等の表記ゆれを厳密比較で
+            # 取り逃すと「0ファイルにマッチする死にパターン」として黙って素通りする (#32)。
+            FOLDED="$(echo "${STRIPPED}" | tr '[:upper:]' '[:lower:]')"
             # 空文字・空白のみも「宣言なし」— none という明示宣言か、実パスのどちらかを必須にする。
-            if [ -z "$STRIPPED" ] || [ "$STRIPPED" = "__DECLARE_ME__" ]; then
+            if [ -z "$STRIPPED" ] || [ "$FOLDED" = "__declare_me__" ]; then
               echo "::error::${NAME} is empty or still the placeholder. Declare paths for this category, or declare 'none' explicitly — an undeclared category must not silently pass (fail-closed)."
               exit 1
             fi
-            if [ "$STRIPPED" != "none" ]; then
+            if [ "$FOLDED" != "none" ]; then
               RISK_PATHS_REPO="${RISK_PATHS_REPO}${VAL}"$'\n'
             fi
           }
           check_category RISK_PATHS_BILLING "$RISK_PATHS_BILLING"
           check_category RISK_PATHS_OUTBOUND "$RISK_PATHS_OUTBOUND"
           check_category RISK_PATHS_GATES "$RISK_PATHS_GATES"
+          check_category RISK_PATHS_AUTH "$RISK_PATHS_AUTH"
+
+          # 死にパターン検知 (LC-5: 検知→警告・自動では赤にしない): 宣言パターンが HEAD の
+          # 1ファイルにも解決しない場合、リネーム・配置変更で写像が乖離した兆候 — 「存在しない
+          # 敵を守れているように見える」まさに #31 の形。ログの警告で人間の判断に回す。
+          while IFS= read -r pat; do
+            pat="$(echo "$pat" | sed 's/^[[:space:]]*//; s/[[:space:]]*$//')"
+            [ -n "$pat" ] || continue
+            RESOLVED=$(git ls-files -- ":(glob,icase)${pat}") || RESOLVED=""
+            if [ -z "$RESOLVED" ]; then
+              echo "::warning::declared risk pattern '${pat}' matches 0 tracked files at HEAD — possible dead pattern. Update the category declaration (a stale mapping silently uncovers the area)."
+            fi
+          done <<< "${RISK_PATHS_REPO}"
 
           git rev-parse --verify "origin/${BASE_REF}" >/dev/null || {
             echo "::error::base ref not found — failing closed (FP-6)."; exit 1; }

--- a/templates/ci/review-labels.yml
+++ b/templates/ci/review-labels.yml
@@ -63,6 +63,9 @@ jobs:
         name: Match changed files against risk paths
         env:
           BASE_REF: ${{ github.base_ref }}
+          # 文字クラス ([[:space:]])・tr・sed を決定論にする。LC_ALL=C だと全角空白 (U+3000)
+          # が空白と分類されず、行内空白の赤検査をすり抜けて 0 マッチの静かな緑になる (実測)。
+          LANG: C.UTF-8
         run: |
           set -euo pipefail
           # 高リスク領域のパス写像 (定義の正本は handbook docs/06 — ここは写像だけ)。
@@ -143,16 +146,29 @@ jobs:
               line="$(echo "$line" | sed 's/^[[:space:]]*//; s/[[:space:]]*$//')"
               [ -n "$line" ] || continue
               case "$line" in
+                '#'*)
+                  # コメント行は宣言の中では未対応 — 空白の有無で挙動が割れる (空白ありは
+                  # 空白検査・空白なしは死にパターン化) のを許さず、正しい理由で赤にする。
+                  echo "::error::${NAME} contains a comment line ('${line}') — comments are not supported inside category declarations; remove it (fail-closed)."
+                  exit 1
+                  ;;
                 *[[:space:]]*)
                   echo "::error::${NAME} line '${line}' contains internal whitespace — declare one pattern per line (a space-separated list becomes ONE literal-space pathspec matching 0 files = silent fail-open). Use glob ? for a path that really contains a space."
                   exit 1
                   ;;
               esac
-              LINE_FOLDED="$(echo "$line" | tr '[:upper:]' '[:lower:]')"
-              case "$LINE_FOLDED" in
-                *declare_me*)
-                  echo "::error::${NAME} contains a placeholder-like line ('${line}') — remove it and declare real paths or 'none' (fail-closed)."
-                  exit 1
+              # プレースホルダ検査は / も . も含まない行だけに掛ける — 実パターンは区切りか
+              # 拡張子を持つ (app/declare_member.py 等の実在パスを誤って赤にしない)。
+              case "$line" in
+                */*|*.*) : ;;
+                *)
+                  LINE_FOLDED="$(echo "$line" | tr '[:upper:]' '[:lower:]')"
+                  case "$LINE_FOLDED" in
+                    *declare_me*)
+                      echo "::error::${NAME} contains a placeholder-like line ('${line}') — remove it and declare real paths or 'none' (fail-closed)."
+                      exit 1
+                      ;;
+                  esac
                   ;;
               esac
             done <<< "${VAL}"
@@ -170,14 +186,16 @@ jobs:
           while IFS= read -r pat; do
             pat="$(echo "$pat" | sed 's/^[[:space:]]*//; s/[[:space:]]*$//')"
             [ -n "$pat" ] || continue
-            if RESOLVED=$(git ls-files -- ":(glob,icase)${pat}" 2>&1); then
+            # stderr は空判定に混ぜない — 成功時の stderr が「0マッチなのに生きて見える」形で
+            # 死にパターン警告を黙らせる経路を作らない (エラー詳細は失敗時に再実行で表示)。
+            if RESOLVED=$(git ls-files -- ":(glob,icase)${pat}" 2>/dev/null); then
               if [ -z "$RESOLVED" ]; then
                 echo "::warning::declared risk pattern '${pat}' matches 0 tracked files at HEAD — possible dead pattern. Update the category declaration (a stale mapping silently uncovers the area)."
               fi
             else
               # 解決失敗は「死にパターン」でなく構文不正 — 誤診しない (診断を分ける)。
               # この後の diff 照合ループが同じパターンで fail-closed に落とす。
-              printf '%s\n' "$RESOLVED"
+              git ls-files -- ":(glob,icase)${pat}" 2>&1 >/dev/null | sed 's/^/  /' || true
               echo "::warning::declared risk pattern '${pat}' could not be resolved as a pathspec (git error above) — fix the declaration syntax; the diff-matching step will fail closed on it."
             fi
           done <<< "${RISK_PATHS_REPO}"

--- a/templates/ci/review-labels.yml
+++ b/templates/ci/review-labels.yml
@@ -89,9 +89,12 @@ jobs:
           # 1ファイル PR で無力化する経路 (make test を true 化等) を人間確認の対象に入れる
           # (handbook#28・icase 照合なので makefile 等の大小変種も **/Makefile が拾う)。
           # CUSTOMIZE (宣言必須・カテゴリ別): このリポ固有のパスをカテゴリごとに列挙する。
-          # 該当が無いカテゴリは none と明示宣言する (大小文字は問わない)。どれか一つでも
-          # __DECLARE_ME__ のまま (宣言なし) なら赤 — 「書き忘れたカテゴリだけ静かに fail-open」を
-          # カテゴリ単位で許さない (fail-closed)。
+          # パターンは 1行1パターンの改行区切り — 空白区切りで1行に並べると「空白を含む1つの
+          # pathspec」として 0 ファイルにマッチする静かな fail-open になるため、行内空白は下の
+          # 検査で赤にする (空白を含む実パスは glob の ? で表す)。該当が無いカテゴリは none と
+          # だけ明示宣言する (受理する語は none のみ・大小文字不問。n/a 等の同義語は不可)。
+          # どれか一つでも __DECLARE_ME__ のまま (宣言なし) なら赤 — 「書き忘れたカテゴリだけ
+          # 静かに fail-open」をカテゴリ単位で許さない (fail-closed)。
           RISK_PATHS_BILLING='__DECLARE_ME__'   # 課金・支出 (例: **/billing/**) — 該当なしなら none
           RISK_PATHS_OUTBOUND='__DECLARE_ME__'  # 対外公開・対人送信 (例: **/publish/**) — 該当なしなら none
           RISK_PATHS_GATES='__DECLARE_ME__'     # 門番の実体 (test/lint が呼ぶリポ固有スクリプト・設定。例: scripts/readme-check/**) — DEFAULT の Makefile/scripts/ci/** で足りるなら none
@@ -99,7 +102,13 @@ jobs:
           # 「認証コードは auth/ ディレクトリにある」という配置前提で、フラット配置 (app/auth.py・
           # app/apple_signin.py 等) のリポでは 0 ファイルにマッチし、認証高リスク面がまるごと網外に
           # なる。配置前提を型に埋めず、リポごとの明示宣言 (fail-closed) に乗せる。
-          RISK_PATHS_AUTH='__DECLARE_ME__'      # 認証・権限境界 (例: app/auth*.py **/token*.py) — 認証コードが auth/ ディレクトリ配下に集約済み (DEFAULT の **/auth/** が実ファイルを拾う) なら none
+          # 認証コードが auth/ ディレクトリ配下に集約済み (DEFAULT の **/auth/** が実ファイルを
+          # 拾う) なら none。複数パターンの宣言形 (1行1パターン):
+          #   RISK_PATHS_AUTH='
+          #     app/auth*.py
+          #     **/token*.py
+          #   '
+          RISK_PATHS_AUTH='__DECLARE_ME__'      # 認証・権限境界 — 該当パスを列挙 or none
 
           RISK_PATHS_REPO=''
           check_category() {
@@ -113,9 +122,41 @@ jobs:
               echo "::error::${NAME} is empty or still the placeholder. Declare paths for this category, or declare 'none' explicitly — an undeclared category must not silently pass (fail-closed)."
               exit 1
             fi
-            if [ "$FOLDED" != "none" ]; then
-              RISK_PATHS_REPO="${RISK_PATHS_REPO}${VAL}"$'\n'
+            if [ "$FOLDED" = "none" ]; then
+              # AUTH の none は「auth コードが無い」か「DEFAULT の **/auth/** が実カバーしている」
+              # という主張。フラット配置の auth コードを持つリポが none と書くと警告ゼロで網外に
+              # なる (#31 の残余) — 主張を HEAD で自己検証する (LC-5: 検知→警告・赤にしない)。
+              if [ "$NAME" = "RISK_PATHS_AUTH" ]; then
+                AUTH_FILES=$(git ls-files -- ':(glob,icase)**/auth/**') || AUTH_FILES=""
+                if [ -z "$AUTH_FILES" ]; then
+                  echo "::warning::RISK_PATHS_AUTH is 'none' but DEFAULT's **/auth/** matches 0 tracked files — if this repo has flat-layout auth code (e.g. app/auth.py), the auth surface is entirely uncovered (#31). Verify the 'none' claim or declare real paths."
+                fi
+              fi
+              return 0
             fi
+            # 行単位の健全性検査 (3席レビュー収束・#33):
+            # - 行内空白 = 空白区切りの複数パターン誤記。git pathspec では空白が literal 文字の
+            #   1パターンになり 0 件マッチ=静かな fail-open になるため赤。
+            # - declare_me を含む行 = プレースホルダの残骸・打ち間違い (__DECLARE_ME_ 等)。
+            #   実パスと混在した部分宣言も赤 (「宣言なしは赤」の契約を行単位でも守る)。
+            while IFS= read -r line; do
+              line="$(echo "$line" | sed 's/^[[:space:]]*//; s/[[:space:]]*$//')"
+              [ -n "$line" ] || continue
+              case "$line" in
+                *[[:space:]]*)
+                  echo "::error::${NAME} line '${line}' contains internal whitespace — declare one pattern per line (a space-separated list becomes ONE literal-space pathspec matching 0 files = silent fail-open). Use glob ? for a path that really contains a space."
+                  exit 1
+                  ;;
+              esac
+              LINE_FOLDED="$(echo "$line" | tr '[:upper:]' '[:lower:]')"
+              case "$LINE_FOLDED" in
+                *declare_me*)
+                  echo "::error::${NAME} contains a placeholder-like line ('${line}') — remove it and declare real paths or 'none' (fail-closed)."
+                  exit 1
+                  ;;
+              esac
+            done <<< "${VAL}"
+            RISK_PATHS_REPO="${RISK_PATHS_REPO}${VAL}"$'\n'
           }
           check_category RISK_PATHS_BILLING "$RISK_PATHS_BILLING"
           check_category RISK_PATHS_OUTBOUND "$RISK_PATHS_OUTBOUND"
@@ -125,12 +166,19 @@ jobs:
           # 死にパターン検知 (LC-5: 検知→警告・自動では赤にしない): 宣言パターンが HEAD の
           # 1ファイルにも解決しない場合、リネーム・配置変更で写像が乖離した兆候 — 「存在しない
           # 敵を守れているように見える」まさに #31 の形。ログの警告で人間の判断に回す。
+          # 展開手順の機械確認にはこのログの ::warning:: 確認を含める (README 手順 6)。
           while IFS= read -r pat; do
             pat="$(echo "$pat" | sed 's/^[[:space:]]*//; s/[[:space:]]*$//')"
             [ -n "$pat" ] || continue
-            RESOLVED=$(git ls-files -- ":(glob,icase)${pat}") || RESOLVED=""
-            if [ -z "$RESOLVED" ]; then
-              echo "::warning::declared risk pattern '${pat}' matches 0 tracked files at HEAD — possible dead pattern. Update the category declaration (a stale mapping silently uncovers the area)."
+            if RESOLVED=$(git ls-files -- ":(glob,icase)${pat}" 2>&1); then
+              if [ -z "$RESOLVED" ]; then
+                echo "::warning::declared risk pattern '${pat}' matches 0 tracked files at HEAD — possible dead pattern. Update the category declaration (a stale mapping silently uncovers the area)."
+              fi
+            else
+              # 解決失敗は「死にパターン」でなく構文不正 — 誤診しない (診断を分ける)。
+              # この後の diff 照合ループが同じパターンで fail-closed に落とす。
+              printf '%s\n' "$RESOLVED"
+              echo "::warning::declared risk pattern '${pat}' could not be resolved as a pathspec (git error above) — fix the declaration syntax; the diff-matching step will fail closed on it."
             fi
           done <<< "${RISK_PATHS_REPO}"
 

--- a/templates/ci/review-labels.yml
+++ b/templates/ci/review-labels.yml
@@ -65,7 +65,9 @@ jobs:
           BASE_REF: ${{ github.base_ref }}
           # 文字クラス ([[:space:]])・tr・sed を決定論にする。LC_ALL=C だと全角空白 (U+3000)
           # が空白と分類されず、行内空白の赤検査をすり抜けて 0 マッチの静かな緑になる (実測)。
-          LANG: C.UTF-8
+          # LANG でなく LC_ALL を pin する — LC_ALL は全 LC_* と LANG に優先し、runner 側の
+          # export に上書きされない (R3 3席収束)。
+          LC_ALL: C.UTF-8
         run: |
           set -euo pipefail
           # 高リスク領域のパス写像 (定義の正本は handbook docs/06 — ここは写像だけ)。


### PR DESCRIPTION
Closes #31, closes #32. #30 の README 3点追記も同便（#30 は展開2リポの検証で同フィクスチャを使い終えてから閉じる運用でも可 — マージで自動 close される設定のため、残す場合は言ってください → 本 PR では close 指定を #31/#32 のみにしています）。

## What（型 v0.9.2・第1陣で還流した欠陥3件の一括改訂）

**#31 — 第4常設カテゴリ `RISK_PATHS_AUTH` 新設**（席団推奨 (b) 採用・(a) DEFAULT への glob 追加は過剰マッチ検討が要るため不採用）
- DEFAULT の `**/auth/**` は「認証コードは auth/ ディレクトリにある」配置前提で、フラット配置リポでは 0 マッチ＝認証面がまるごと網外（caty-cloud#96 で Grok/Kimi 2席独立発見・pathspec 実測付き）
- GATES（#28）と同型: `__DECLARE_ME__` fail-closed・「該当なし」も `none` の明示宣言必須。DEFAULT の `**/auth/**` は残置（auth/ 集約リポの既定網として機能し続ける）

**#32 — none 判定の大小文字硬化+死にパターン警告**
- `none` / `__DECLARE_ME__` の照合を小文字化後に変更 — `None`/`NONE` が「0ファイルにマッチする死にパターン」として静かに fail-open する経路を封鎖（caty-cloud#96 Opus 席 F9）
- 追加: 宣言パターンが HEAD の tracked files に1つも解決しない場合 `::warning::` を出す（LC-5: 検知→警告→人が判断・赤にはしない）。#31 の「存在しない敵を守れているように見える」形を実行時にも可視化

**#30 — templates/ci/README.md 落とし穴3点**
1. 検証用ダミー secret は検知確認済みフィクスチャ（切り詰め PEM）— bare AKIA は gitleaks 8.30.1 既定ルールで検知されない。仕込みは contents API のサーバーサイドコミット推奨（ローカル secret フックとのデッドロック回避）
2. test/lint 充て先は「対象0件で緑」にならない形に（対象カウント+0件=赤・harness#30 で3席収束）
3. シェルの lint は `*.sh` glob+shebang スキャン併用（拡張子なしスクリプトの漏れ）

CUSTOMIZE 手順・早見表にも AUTH カテゴリを追従。

## Files（WIP 宣言どおり）

- `templates/ci/review-labels.yml`
- `templates/ci/README.md`

templates/ci/** のみ — risk 網外（.github/workflows/** には触れない。展開済み3リポへの同期は型確定後の別 PR）。

## Verification

- `make test` / `make lint` 緑（README 4言語 langs 一致含む）
- YAML パース OK・埋め込み detect スクリプト `bash -n` OK
- `check_category` 挙動テスト 13/13 PASS（none/None/NONE/空白混じり=skip・`__DECLARE_ME__` 大小混在/空文字/空白のみ=赤・実パス/`nonexistent/**`〔none を含む語〕=採用）
- 死にパターンループ実走: 解決するパターン=OK・0マッチパターン=WARN を確認

## レビュー

S/M 3席（GLM 5.2 常設+ローテ2席）を本 PR 上で実施予定。enforcement 型のため「最悪の失敗形」= **表記ゆれ・宣言忘れ・写像乖離のどれかが『静かに緑』になる経路の見逃し**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
