### PR TITLE
chore: record first nightshift wake

### DIFF
--- a/nightshift-dryrun/first-wake.md
+++ b/nightshift-dryrun/first-wake.md
@@ -1,0 +1,5 @@
+# First wake
+
+- Wake time (UTC): 2026-08-12T16:31:18Z
+- Trigger: manual single-cycle
+- Alec: 止め方まで証明できて、初めて自動化は出荷できる。


### PR DESCRIPTION
Closes the dry-run artifact portion of #41.

- records the UTC wake timestamp
- records the manual single-cycle trigger
- includes Alec’s one-sentence note

Constraints honored: one file only; do not merge.

Related: #40