### PR TITLE
templates/publication-gate: shared gate + external .publication-denylist (#83, W0-5)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ LINT_TARGETS := $(READMES) i18n/README.md
 
 .PHONY: test lint
 
-# test: 非空ガード + 4言語 README 構造一致 + seat-resolver unit/conformance gates — fail-closed
+# test: 非空ガード + 4言語 README 構造一致 + seat-resolver unit/conformance + publication-gate self-test — fail-closed
 test:
 	@/bin/sh scripts/test.sh
 

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -45,6 +45,7 @@ register_suite # README files are present and non-empty.
 register_suite # The four localized READMEs have matching structure.
 register_suite # Seat-resolver unit tests.
 register_suite # Seat-resolver conformance vectors.
+register_suite # Publication-gate self-test.
 
 if [ "$#" -ne 0 ]; then
     printf 'FAIL usage (expected=no-arguments)\n' >&2
@@ -109,6 +110,7 @@ run_suite readme-nonempty check_readmes
 run_suite readme-structure "$python_bin" -B scripts/readme-check/inspect_readme.py langs README.ja.md README.md README.zh.md README.th.md
 run_suite seat-resolver-unit "$python_bin" -B -m unittest discover -s templates/seat-resolver/tests -v
 run_suite seat-resolver-conformance run_conformance
+run_suite publication-gate-template "$python_bin" -B templates/publication-gate/check_publication_gate.py --selftest
 
 if [ "$failures" -ne 0 ]; then
     exit 1

--- a/templates/publication-gate/README.md
+++ b/templates/publication-gate/README.md
@@ -1,0 +1,132 @@
+# templates/publication-gate — 公開前ゲートの配布用 stencil
+
+家族のリポが対外公開用の表示に個人用 URL・公開禁止語・不整合な公開ラベルを残したまま
+merge されるのを、ローカルと CI の同じ検査で止めるための配布用の型。正本は
+`templates/publication-gate/check_publication_gate.py`。導入先では例えば
+`tools/check_publication_gate.py` としてコピーし、リポ固有のポリシーだけをルートの外部ファイルで持つ。
+
+これは公開前の**機械の一次ゲート**であり、人間の公開決裁や多席レビューの代替ではない。
+スクリプトが赤を返すだけでは merge は止まらないため、導入先の CI job を branch protection の
+required status check に登録して初めて「保護済み」と扱う。
+
+## 何を守るか
+
+| 検査 | 守るもの | レジストリなしの挙動 |
+|---|---|---|
+| 外部 denylist | リポ固有の公開禁止語が corpus に残らないこと | 常に検査 |
+| 個人用 URL | `--account-slug` の個人アカウント URL が残らないこと | アカウント profile もその slug 下のリポ URL も、corpus 内の any-hit で1件でも見つかれば赤 |
+| 個人 URL の registry allowlist | 台帳で公開対象と宣言した URL だけを個人用 URL 検査から免除すること | allowlist 検査を skip し、明示的な notice を出す |
+| 公開ラベル | 台帳の対象に公開ラベルが無い状態を残さないこと | 「ラベル欠落」検査を skip し、notice を出す |
+| SVG 状態 | README の表示と台帳の公開状態が食い違わないこと | 検査を skip し、notice を出す |
+| label whitelist の stale | 一時的な例外が台帳変更後も残らないこと | 検査を skip し、notice を出す |
+
+`--registry` は任意。省略した場合も denylist と個人用 URL の検査は実行し、確認不能な
+4検査を黙って緑にせず、それぞれ skip notice を出す。corpus のアンカーは、レジストリ有りなら
+指定した JSON ファイル、無しなら `<root>/README.md` へ fallback する。カレントディレクトリ下の別 README を
+偶然拾って判定の起点にはしない。レジストリなしで `<root>/README.md` も無い場合は、corpus floor を
+確立できないため赤になる。
+
+## 展開手順（コピペ順）
+
+1. checker を導入先へコピーする。配置先はリポの慣例に合わせてよいが、以下では
+   `tools/check_publication_gate.py` とする。
+   ```bash
+   cp templates/publication-gate/check_publication_gate.py <target-repo>/tools/check_publication_gate.py
+   ```
+2. sample denylist を導入先リポのルートへコピーし、実ポリシーに置き換える。
+   `.publication-denylist` は必須で、無い・空のままなら赤になる。
+   ```bash
+   cp templates/publication-gate/fixtures/sample.publication-denylist <target-repo>/.publication-denylist
+   ```
+3. CI に通常検査を配線する。レジストリを持つリポは `--registry` も渡す。
+   ```bash
+   python3 -B tools/check_publication_gate.py \
+     --root . \
+     --account-slug "$PUBLICATION_ACCOUNT_SLUG" \
+     --registry path/to/modules.json
+   ```
+   レジストリを使わないリポは最後の2引数を省略する。`--registry` を省略しても
+   `--account-slug` は省略できない。個人用 URL 検査は通常実行で常に有効で、slug 未指定は
+   ゲートの設定不備として赤になる。
+4. checker の self-test と導入先のテストを同じ CI job か依存 job で実行し、その status
+   check を branch protection の required に登録する。ローカルでも同じ経路が通るよう
+   Makefile の `test` ターゲットに配線し、導入完了前に実行する。
+   ```bash
+   python3 -B tools/check_publication_gate.py --selftest
+   make test
+   ```
+
+本ハンドブック自身の `make test` も、配布用 checker の `--selftest` を実行する。
+
+## `.publication-denylist` の正確な形式
+
+ファイルは UTF-8 テキスト。1行1ルールで、次の形式だけを受け付ける。
+
+```text
+NAME<TAB>REGEX
+```
+
+- 空行と、**先頭文字**が `#` の行は無視する。`#` の前に空白がある行はコメントではない。
+- 最初のタブだけで `NAME` と `REGEX` に分ける。正規表現側にタブを含める場合も、第2フィールドの
+  一部として扱う。
+- `NAME` と `REGEX` はどちらも空にできない。`REGEX` は Python `re` の構文で、
+  `re.IGNORECASE` でコンパイル・照合する。
+- タブの無い行、空のフィールド、コンパイルできない正規表現、UTF-8 として読めないファイルは
+  **malformed = 赤**。
+- `.publication-denylist` 自体の不在と、コメント/空行を除く有効ルール0件はどちらも**赤**。
+
+denylist は検出すべき禁止リテラルを必然的に含む。そのため checker は、スキャン対象から
+`<root>/.publication-denylist` を**パスで**自己除外する。過去のようにスクリプト内で禁止語を分割文字列にして
+検出をかわすハックは不要。ポリシーと実装を分けたまま、自己検知だけを明示的に除外できる。
+
+## 任意の `.publication-label-whitelist`
+
+公開ラベルの既知の例外が必要なときだけ、リポルートに作成する。UTF-8、1行1例外で形式は次の通り。
+
+```text
+PATH<TAB>EXACT_LINE
+```
+
+`PATH` と、そのファイル内で許可する `EXACT_LINE` の完全一致だけを免除する。このファイルは
+**言い訳だけを追加する** allowlist であり、新しい問題を検出するポリシーではない。したがって不在時は
+fail-open（免除なしとして継続）でよい。denylist の不存を赤にするのとは非対称だが、意図的な設計である。
+`--registry` が無い場合は whitelist-staleness を判定できないため、その検査は notice 付きで skip する。
+
+## CLI
+
+| 引数 | 必須性 / 既定値 | 意味 |
+|---|---|---|
+| `--root PATH` | 任意、既定 `.` | 検査対象リポのルート。ポリシーファイルと、レジストリ省略時の `README.md` のアンカー |
+| `--account-slug SLUG` | 通常検査で必須、既定なし | 公開物に残してはいけない個人アカウントの slug。未指定は赤 |
+| `--registry PATH` | 任意、既定なし | 公開リポ台帳の JSON ファイル。無い場合は台帳依存の4検査だけを notice 付きで skip |
+| `--selftest` | 任意、既定 `false` | 内蔵 fixture で parser・検出・fail posture を検査して終了 |
+
+## スキャン対象と Git の無い環境
+
+Git worktree では Git から得られる corpus を使う。アーカイブ展開後やコピー先など Git の無い環境でも
+検査自体を消さず、`Path.rglob()` 相当でルート以下を再帰走査する。その際は次のディレクトリを対象外にする。
+
+```text
+.git
+.omc
+.omx
+.venv
+venv
+node_modules
+__pycache__
+```
+
+## family-os / organization `.github` からの移行
+
+`family-os` と organization `.github` にある局所コピーは、この stencil の挙動を先に確定した後、
+後続の **B9 lane** で置き換える。このテンプレート導入と既存リポの移行を同じ diff で混ぜない。
+
+移行時の意図的な差分は2つ。
+
+- 旧コピーの email masking のバグは修正済みで、新チェッカーの方が**厳格**。以前通っていた表記が
+  新しく赤になった場合、検知退行ではなく bug fix の結果として対象テキストを直す。
+- 外部 `.publication-denylist` は必須。先にファイルを配置・カスタマイズせず checker だけを切り替えると、
+  ゲートは意図的に赤のままになる。
+
+移行 PR では `--selftest`、対象リポの `make test`、通常 CLI の実行結果、CI status check の
+required 登録を証拠として残す。

--- a/templates/publication-gate/README.md
+++ b/templates/publication-gate/README.md
@@ -14,7 +14,7 @@ required status check に登録して初めて「保護済み」と扱う。
 | 検査 | 守るもの | レジストリなしの挙動 |
 |---|---|---|
 | 外部 denylist | リポ固有の公開禁止語が corpus に残らないこと | 常に検査 |
-| 個人用 URL | `--account-slug` の個人アカウント URL が残らないこと | アカウント profile もその slug 下のリポ URL も、corpus 内の any-hit で1件でも見つかれば赤 |
+| 個人用 URL | `--account-slug` の個人アカウント URL が残らないこと | アカウント profile、slug 下のリポ URL、gist、GitHub Pages の any-hit が1件でも見つかれば赤 |
 | 個人 URL の registry allowlist | 台帳で公開対象と宣言した URL だけを個人用 URL 検査から免除すること | allowlist 検査を skip し、明示的な notice を出す |
 | 公開ラベル | 台帳の対象に公開ラベルが無い状態を残さないこと | 「ラベル欠落」検査を skip し、notice を出す |
 | SVG 状態 | README の表示と台帳の公開状態が食い違わないこと | 検査を skip し、notice を出す |
@@ -25,6 +25,12 @@ required status check に登録して初めて「保護済み」と扱う。
 指定した JSON ファイル、無しなら `<root>/README.md` へ fallback する。カレントディレクトリ下の別 README を
 偶然拾って判定の起点にはしない。レジストリなしで `<root>/README.md` も無い場合は、corpus floor を
 確立できないため赤になる。
+
+個人用 URL は URL 候補を解析して host を正規化してから照合する。`github.com/<slug>` に加え、
+`github.com:443/<slug>`、`github.com./<slug>`、`gist.github.com/<slug>`、
+`<slug>.github.io` も対象になる。host の port は無視し、末尾の dot は1個だけ除く。
+`--account-slug` は前後の空白を除いた後、GitHub slug 形の
+`^[A-Za-z0-9](?:[A-Za-z0-9-]{0,37})$` に一致しなければ設定不備として赤になる。
 
 ## 展開手順（コピペ順）
 
@@ -45,7 +51,8 @@ required status check に登録して初めて「保護済み」と扱う。
      --account-slug "$PUBLICATION_ACCOUNT_SLUG" \
      --registry path/to/modules.json
    ```
-   レジストリを使わないリポは最後の2引数を省略する。`--registry` を省略しても
+   レジストリを使わないリポは最後の2引数を省略する。機微パターンを CI secret から
+   注入する場合は `--denylist "$PUBLICATION_DENYLIST_PATH"` も渡す。`--registry` を省略しても
    `--account-slug` は省略できない。個人用 URL 検査は通常実行で常に有効で、slug 未指定は
    ゲートの設定不備として赤になる。
 4. checker の self-test と導入先のテストを同じ CI job か依存 job で実行し、その status
@@ -67,17 +74,37 @@ NAME<TAB>REGEX
 ```
 
 - 空行と、**先頭文字**が `#` の行は無視する。`#` の前に空白がある行はコメントではない。
-- 最初のタブだけで `NAME` と `REGEX` に分ける。正規表現側にタブを含める場合も、第2フィールドの
-  一部として扱う。
-- `NAME` と `REGEX` はどちらも空にできない。`REGEX` は Python `re` の構文で、
+- 1行目の先頭に UTF-8 BOM があれば、BOM だけを除いてからコメント/ルールとして解釈する。
+- 最初のタブで `NAME` と `REGEX` に分ける。追加の literal tab は列ずれとして拒否するため、
+  正規表現で tab を表したいときは `\t` と書く。
+- `NAME` は空にできず、space/tab/newline などの whitespace を一切含められない。
+  `REGEX` も空にできず、先頭・末尾に whitespace を置けない。whitespace 自体を照合したい場合は
+  `\s` または `[ ]` を明示する。`REGEX` は Python `re` の構文で、
   `re.IGNORECASE` でコンパイル・照合する。
-- タブの無い行、空のフィールド、コンパイルできない正規表現、UTF-8 として読めないファイルは
+- タブの無い行、不正な `NAME`、空または前後 whitespace 付きの `REGEX`、追加の literal tab、
+  コンパイルできない正規表現、UTF-8 として読めないファイルは
   **malformed = 赤**。
 - `.publication-denylist` 自体の不在と、コメント/空行を除く有効ルール0件はどちらも**赤**。
 
 denylist は検出すべき禁止リテラルを必然的に含む。そのため checker は、スキャン対象から
-`<root>/.publication-denylist` を**パスで**自己除外する。過去のようにスクリプト内で禁止語を分割文字列にして
+既定の `<root>/.publication-denylist`、または `--denylist` で明示したファイルが root 内にある場合は
+そのファイルを**パスで**自己除外する。この path-exclusion は、拡張子 allowlist を廃止して全 regular file を
+読む現在の実装で load-bearing な安全条件である。過去のようにスクリプト内で禁止語を分割文字列にして
 検出をかわすハックは不要。ポリシーと実装を分けたまま、自己検知だけを明示的に除外できる。
+
+検査結果には `denylist rules loaded : N` を必ず表示する。構文上は有効でも決して一致しない正規表現の
+意味的な妥当性は、trusted policy を書く作者の責任としてこの件数とレビューで確認する。
+
+## denylist 自体の公開リスク
+
+denylist を commit すると、そのパターンも公開物になる。導入先は次の3つから方針を選ぶ。
+
+- **(a) 公開安全なパターン記法で書く**: sample の流儀で、パターン文字列自体が秘密を含まない形にする。
+- **(b) 推奨（機微パターン）**: denylist を `.gitignore` に入れ、CI では secret から一時ファイルへ注入し、
+  `--denylist PATH` でそのファイルを指定する。
+- **(c) 公開を明示的に受け入れる**: パターンの公開リスクを評価し、commit する判断を記録する。
+
+B9 移行では、各リポが (a)〜(c) のどれを採ったかをリポごとに選び、移行記録へ残す。
 
 ## 任意の `.publication-label-whitelist`
 
@@ -99,12 +126,18 @@ fail-open（免除なしとして継続）でよい。denylist の不存を赤�
 | `--root PATH` | 任意、既定 `.` | 検査対象リポのルート。ポリシーファイルと、レジストリ省略時の `README.md` のアンカー |
 | `--account-slug SLUG` | 通常検査で必須、既定なし | 公開物に残してはいけない個人アカウントの slug。未指定は赤 |
 | `--registry PATH` | 任意、既定なし | 公開リポ台帳の JSON ファイル。無い場合は台帳依存の4検査だけを notice 付きで skip |
+| `--denylist PATH` | 任意、既定 `<root>/.publication-denylist` | 外部 denylist。相対パスは root 基準。root 内なら明示指定したファイルもスキャンから path-exclude |
 | `--selftest` | 任意、既定 `false` | 内蔵 fixture で parser・検出・fail posture を検査して終了 |
 
 ## スキャン対象と Git の無い環境
 
-Git worktree では Git から得られる corpus を使う。アーカイブ展開後やコピー先など Git の無い環境でも
-検査自体を消さず、`Path.rglob()` 相当でルート以下を再帰走査する。その際は次のディレクトリを対象外にする。
+Git worktree（root に `.git` entry がある場合）では、`git ls-files --cached --others --exclude-standard`
+が列挙する全 path を publishable corpus とみなす。Git mode では下記ディレクトリ除外を適用せず、
+commit 済みなら `node_modules/` 下も検査する。root に `.git` entry があるのに Git 列挙が失敗した場合は、
+`rglob` へ黙って fallback せず `gate-error` で赤にする。
+
+root に `.git` entry が無いアーカイブ展開後やコピー先では、検査自体を消さず `Path.rglob()` 相当で
+ルート以下を再帰走査する。この `rglob-fallback` でだけ、次のディレクトリを対象外にする。
 
 ```text
 .git
@@ -115,6 +148,19 @@ venv
 node_modules
 __pycache__
 ```
+
+列挙された regular file は suffix やファイル名で選別せず、`.env`、`LICENSE`、`Dockerfile`、`.txt`、
+拡張子なしもすべて UTF-8 decode を試す。decode できないファイルは binary としてスキャンを飛ばすが、
+`binary files skipped: N` に必ず集計する。Git mode の symlink は Git が公開する readlink text を検査する。
+`rglob-fallback` は symlink を follow せず、`symlinks skipped: N` に集計する。
+
+summary は必ず `enumeration: git` または `enumeration: rglob-fallback` と、
+`denylist rules loaded : N` を表示する。raw view の hit は raw text の行番号を使い、percent/HTML decode 後に
+初めて見つかった hit は decoded text の行番号と `(decoded view)` marker を表示する。
+
+`--selftest` の violating corpus、clean twin、sample denylist は checker 自体の string constants として
+埋め込まれている。disk 上の `fixtures/` は人間向け資料であり selftest の依存ではないため、checker の
+`.py` だけを別ディレクトリへコピーしても `--selftest` は完走する。
 
 ## family-os / organization `.github` からの移行
 

--- a/templates/publication-gate/check_publication_gate.py
+++ b/templates/publication-gate/check_publication_gate.py
@@ -1,0 +1,757 @@
+#!/usr/bin/env python3
+"""Fail closed when publication sources expose private context or stale state.
+
+The denylist is repository policy, not checker source.  Normal runs require an
+account slug so personal-account URLs are always checked.  Registry-backed
+label, SVG, allowlist, and whitelist-staleness checks are optional.
+
+Python 3.9+, standard library only.
+"""
+
+import argparse
+from contextlib import redirect_stdout
+import html
+import io
+import json
+import os
+from pathlib import Path
+import re
+import shutil
+import stat
+import subprocess
+import sys
+import tempfile
+import urllib.parse
+
+
+SCANNED_SUFFIXES = frozenset((".md", ".json", ".py", ".yml", ".yaml", ".svg", ".sh"))
+EXCLUDED_DIRS = frozenset(
+    (".git", ".omc", ".omx", ".venv", "venv", "node_modules", "__pycache__")
+)
+DENYLIST_NAME = ".publication-denylist"
+WHITELIST_NAME = ".publication-label-whitelist"
+LANG_SUFFIX = re.compile(r"\.(?P<lang>[a-z]{2}(?:-[a-z]{2})?)\.md$")
+SVG_TEXT_ELEMENT = re.compile(
+    r"<(text|title|desc|metadata)\b[^>]*>(.*?)</\1\s*>", re.IGNORECASE | re.DOTALL
+)
+SVG_TEXT_ATTRIBUTE = re.compile(
+    r"\b(?:title|aria-label|alt)\s*=\s*(?P<quote>['\"])(?P<value>.*?)(?P=quote)",
+    re.IGNORECASE | re.DOTALL,
+)
+SVG_CDATA = re.compile(r"<!\[CDATA\[(.*?)\]\]>", re.DOTALL)
+
+
+class GateConfigurationError(ValueError):
+    """A fail-closed policy or command configuration error."""
+
+
+def language_of(path):
+    match = LANG_SUFFIX.search(path.name.lower())
+    return match.group("lang") if match else "en"
+
+
+def scan_views(text):
+    """Return raw plus iterative percent/HTML-decoded views."""
+    views = [text]
+    current = text
+    for _ in range(3):
+        unquoted = urllib.parse.unquote(current)
+        if unquoted not in views:
+            views.append(unquoted)
+        unescaped = html.unescape(unquoted)
+        if unescaped not in views:
+            views.append(unescaped)
+        if unescaped == current:
+            break
+        current = unescaped
+    return tuple(views)
+
+
+def line_number(text, offset):
+    return text.count("\n", 0, offset) + 1
+
+
+def _read_utf8(path, display_name):
+    try:
+        return path.read_text(encoding="utf-8")
+    except (OSError, UnicodeError) as exc:
+        raise GateConfigurationError(
+            "gate-error: %s could not be read as UTF-8: %s" % (display_name, exc)
+        ) from exc
+
+
+def load_denylist(root):
+    """Load NAME<TAB>REGEX policy, failing closed on absence or zero rules."""
+    path = root / DENYLIST_NAME
+    if not path.is_file():
+        raise GateConfigurationError(
+            "gate-error: .publication-denylist missing/empty — a publication gate with no denylist proves nothing (fail-closed)"
+        )
+    text = _read_utf8(path, DENYLIST_NAME)
+    rules = []
+    for number, line in enumerate(text.splitlines(), 1):
+        if not line.strip() or line.startswith("#"):
+            continue
+        if "\t" not in line:
+            raise GateConfigurationError(
+                "gate-error: %s:%d malformed rule: expected NAME<TAB>REGEX"
+                % (DENYLIST_NAME, number)
+            )
+        name, expression = line.split("\t", 1)
+        if not name or not expression:
+            raise GateConfigurationError(
+                "gate-error: %s:%d malformed rule: NAME and REGEX must be non-empty"
+                % (DENYLIST_NAME, number)
+            )
+        try:
+            pattern = re.compile(expression, re.IGNORECASE)
+        except re.error as exc:
+            raise GateConfigurationError(
+                "gate-error: %s:%d invalid regex for %s: %s"
+                % (DENYLIST_NAME, number, name, exc)
+            ) from exc
+        rules.append((name, pattern))
+    if not rules:
+        raise GateConfigurationError(
+            "gate-error: .publication-denylist missing/empty — a publication gate with no denylist proves nothing (fail-closed)"
+        )
+    return tuple(rules)
+
+
+def load_label_whitelist(root):
+    """Load optional PATH<TAB>EXACT_LINE label exemptions."""
+    path = root / WHITELIST_NAME
+    if not path.exists():
+        return frozenset()
+    if not path.is_file():
+        raise GateConfigurationError("gate-error: %s is not a regular file" % WHITELIST_NAME)
+    text = _read_utf8(path, WHITELIST_NAME)
+    entries = set()
+    for number, line in enumerate(text.splitlines(), 1):
+        if not line.strip() or line.startswith("#"):
+            continue
+        if "\t" not in line:
+            raise GateConfigurationError(
+                "gate-error: %s:%d malformed entry: expected PATH<TAB>EXACT_LINE"
+                % (WHITELIST_NAME, number)
+            )
+        path_text, exact_line = line.split("\t", 1)
+        if not path_text or not exact_line:
+            raise GateConfigurationError(
+                "gate-error: %s:%d malformed entry: PATH and EXACT_LINE must be non-empty"
+                % (WHITELIST_NAME, number)
+            )
+        entries.add((Path(path_text).as_posix(), exact_line))
+    return frozenset(entries)
+
+
+def _git_paths(root):
+    try:
+        result = subprocess.run(
+            ["git", "ls-files", "--cached", "--others", "--exclude-standard", "-z"],
+            cwd=str(root),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+        )
+    except OSError:
+        return None
+    if result.returncode != 0:
+        return None
+    paths = []
+    for relative_bytes in filter(None, result.stdout.split(b"\0")):
+        try:
+            relative = relative_bytes.decode("utf-8")
+        except UnicodeError:
+            return None
+        paths.append(root / relative)
+    return paths
+
+
+def iter_source_paths(root):
+    paths = _git_paths(root)
+    if paths is None:
+        paths = root.rglob("*")
+    policy_path = root / DENYLIST_NAME
+    selected = []
+    for path in paths:
+        try:
+            relative = path.relative_to(root)
+        except ValueError:
+            continue
+        if any(part in EXCLUDED_DIRS for part in relative.parts[:-1]):
+            continue
+        if path == policy_path or path.suffix.lower() not in SCANNED_SUFFIXES:
+            continue
+        selected.append(path)
+    return iter(sorted(selected, key=lambda candidate: candidate.relative_to(root).as_posix()))
+
+
+def read_sources(root, failures):
+    documents = {}
+    for path in iter_source_paths(root):
+        relative = path.relative_to(root).as_posix()
+        try:
+            if path.is_symlink():
+                documents[relative] = os.readlink(path)
+                continue
+            if not stat.S_ISREG(os.lstat(path).st_mode):
+                failures.append("source-read: %s is not a regular file" % relative)
+                continue
+            documents[relative] = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeError) as exc:
+            failures.append("source-read: %s could not be read as UTF-8: %s" % (relative, exc))
+    return documents
+
+
+def check_denylist(documents, rules, failures):
+    checked = 0
+    for path, text in documents.items():
+        reported = set()
+        for view in scan_views(text):
+            for description, pattern in rules:
+                for match in pattern.finditer(view):
+                    finding = (line_number(view, match.start()), description)
+                    if finding in reported:
+                        continue
+                    reported.add(finding)
+                    failures.append(
+                        "denylist: %s:%d contains %s" % (path, finding[0], description)
+                    )
+                    checked += 1
+    return checked
+
+
+def personal_url_pattern(account_slug):
+    return re.compile(
+        r"(?<![A-Za-z0-9.-])(?:www\.)?github\.com/"
+        + re.escape(account_slug)
+        + r"(?:/(?P<repo>[A-Za-z0-9_.-]*[A-Za-z0-9_-])(?=$|[^A-Za-z0-9_-])|/?(?![A-Za-z0-9_.-]))",
+        re.IGNORECASE,
+    )
+
+
+def registry_allowlist(registry):
+    repos = {module["repo"] for module in registry["modules"]}
+    repos.update(entry["repo"] for entry in registry.get("retired_repos", []))
+    if not all(isinstance(repo, str) and "/" in repo for repo in repos):
+        raise ValueError("module and retired repository names must be owner/repository strings")
+    return {repo.casefold() for repo in repos}
+
+
+def check_personal_urls(documents, account_slug, registry, failures):
+    pattern = personal_url_pattern(account_slug)
+    allowlist = registry_allowlist(registry) if registry is not None else None
+    checked = 0
+    for path, text in documents.items():
+        reported = set()
+        for view in scan_views(text):
+            for match in pattern.finditer(view):
+                number = line_number(view, match.start())
+                repo_name = match.group("repo")
+                repo = "%s/%s" % (account_slug, repo_name) if repo_name else account_slug
+                finding = (number, repo.casefold())
+                if finding in reported:
+                    continue
+                reported.add(finding)
+                checked += 1
+                if repo_name is None:
+                    failures.append(
+                        "personal-url: %s:%d references personal account profile %s"
+                        % (path, number, account_slug)
+                    )
+                elif allowlist is None:
+                    failures.append(
+                        "personal-url: %s:%d references personal account repository %s"
+                        % (path, number, repo)
+                    )
+                elif repo.casefold() not in allowlist:
+                    failures.append(
+                        "personal-url: %s:%d references unknown repository %s"
+                        % (path, number, repo)
+                    )
+    return checked
+
+
+def check_corpus_floor(documents, anchor, failures):
+    failed = 0
+    if not documents:
+        failures.append("corpus-floor: no publication source documents were scanned")
+        failed += 1
+    if anchor is not None and anchor not in documents:
+        failures.append("corpus-floor: %s was not among scanned documents" % anchor)
+        failed += 1
+    return failed
+
+
+def repo_home_pattern(repo):
+    base = r"(?<![A-Za-z0-9.-])(?:https?://)?(?:www\.)?github\.com/" + re.escape(repo)
+    terminator = r"(?:/(?=$|[^A-Za-z0-9_.~%-])|(?=$|[^/A-Za-z0-9_.-]|\.(?![A-Za-z0-9_-])))"
+    return re.compile(base + terminator, re.IGNORECASE)
+
+
+def check_whitelist_staleness(documents, whitelist, failures):
+    stale = 0
+    for path, expected_line in sorted(whitelist):
+        source = documents.get(path)
+        if source is not None and expected_line in source.split("\n"):
+            continue
+        failures.append("stale-whitelist: %s no longer contains the exact approved line" % path)
+        stale += 1
+    return stale
+
+
+def check_missing_labels(markdown, registry, whitelist, failures):
+    labels = registry["status_labels"]
+    map_repo = registry.get("map_repo")
+    checked = 0
+    for path_text, text in markdown.items():
+        language = language_of(Path(path_text))
+        for module in registry["modules"]:
+            if module["repo"] == map_repo:
+                continue
+            try:
+                label = labels[module["status"]][language]
+            except (KeyError, TypeError) as exc:
+                failures.append(
+                    "missing-label: registry has no label for %s status=%s language=%s (%s)"
+                    % (module.get("repo", "<unknown>"), module.get("status", "<unknown>"), language, exc)
+                )
+                continue
+            pattern = repo_home_pattern(module["repo"])
+            for number, line in enumerate(text.splitlines(), 1):
+                if not pattern.search(line):
+                    continue
+                checked += 1
+                if label not in line and (path_text, line) not in whitelist:
+                    failures.append(
+                        "missing-label: %s:%d links to %s without '%s' on the same line"
+                        % (path_text, number, module["repo"], label)
+                    )
+    return checked
+
+
+def module_names(module):
+    name = module["name"]
+    if isinstance(name, str):
+        names = {name}
+    elif isinstance(name, dict) and all(isinstance(value, str) for value in name.values()):
+        names = set(name.values())
+    else:
+        raise ValueError("modules[].name must be a string or language-to-string object")
+    names.add(module["repo"].rsplit("/", 1)[-1])
+    return {value for value in names if value}
+
+
+def name_pattern(name):
+    return re.compile(r"(?<![A-Za-z0-9])" + re.escape(name) + r"(?![A-Za-z0-9])", re.IGNORECASE)
+
+
+def svg_visible_text(source):
+    chunks = []
+    for match in SVG_TEXT_ELEMENT.finditer(source):
+        preserved = SVG_CDATA.sub(lambda item: item.group(1), match.group(2))
+        chunks.append(html.unescape(re.sub(r"<[^>]+>", " ", preserved)))
+    for match in SVG_TEXT_ATTRIBUTE.finditer(source):
+        chunks.append(html.unescape(match.group("value")))
+    return re.sub(r"\s+", " ", " ".join(chunks)).strip()
+
+
+def markdown_status_evidence(markdown, registry):
+    labels = registry["status_labels"]
+    evidence = {module["repo"]: False for module in registry["modules"]}
+    for path_text, text in markdown.items():
+        language = language_of(Path(path_text))
+        for module in registry["modules"]:
+            try:
+                label = labels[module["status"]][language]
+            except (KeyError, TypeError):
+                continue
+            markers = module_names(module)
+            markers.add("github.com/%s" % module["repo"])
+            if any(
+                label in line and any(name_pattern(marker).search(line) for marker in markers)
+                for line in text.splitlines()
+            ):
+                evidence[module["repo"]] = True
+    return evidence
+
+
+def check_svg_state_sources(svg_documents, markdown, registry, failures):
+    evidence = markdown_status_evidence(markdown, registry)
+    checked = 0
+    for path, source in svg_documents.items():
+        visible = svg_visible_text(source)
+        compact_visible = re.sub(r"\s+", "", visible).casefold()
+        for module in registry["modules"]:
+            for name in sorted(module_names(module)):
+                matched = bool(name_pattern(name).search(visible))
+                if not matched:
+                    compact_name = re.sub(r"\s+", "", name).casefold()
+                    matched = bool(compact_name) and compact_name in compact_visible
+                if not matched:
+                    continue
+                checked += 1
+                if not evidence[module["repo"]]:
+                    failures.append(
+                        "svg-state: %s contains '%s' for %s, but no Markdown line carries its name/link and status label"
+                        % (path, name, module["repo"])
+                    )
+    return checked
+
+
+def load_registry(path):
+    try:
+        registry = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        raise GateConfigurationError(
+            "gate-error: registry could not be read as UTF-8 JSON: %s" % exc
+        ) from exc
+    if not isinstance(registry, dict):
+        raise GateConfigurationError("gate-error: registry must be a JSON object")
+    if not isinstance(registry.get("modules"), list) or not registry["modules"]:
+        raise GateConfigurationError("gate-error: registry modules must be a non-empty list")
+    if not isinstance(registry.get("status_labels"), dict):
+        raise GateConfigurationError("gate-error: registry status_labels must be an object")
+    return registry
+
+
+def partition_documents(documents):
+    markdown = {path: text for path, text in documents.items() if path.lower().endswith(".md")}
+    svg_documents = {path: text for path, text in documents.items() if path.lower().endswith(".svg")}
+    return markdown, svg_documents
+
+
+SKIP_NOTICES = (
+    "notice: registry allowlist check skipped (--registry not provided)",
+    "notice: missing-label check skipped (--registry not provided)",
+    "notice: SVG-state check skipped (--registry not provided)",
+    "notice: whitelist-staleness check skipped (--registry not provided)",
+)
+
+
+def run_gate(root, account_slug, registry_argument=None):
+    root = Path(root).expanduser().resolve()
+    failures = []
+    documents = {}
+    rules = ()
+    whitelist = frozenset()
+    registry = None
+    registry_relative = None
+    corpus_anchor = "README.md"
+    denylist_hits = 0
+    personal_urls = 0
+    root_links = 0
+    svg_names = 0
+
+    if not account_slug:
+        failures.append("gate-error: --account-slug is required for publication URL checks (fail-closed)")
+
+    try:
+        rules = load_denylist(root)
+    except GateConfigurationError as exc:
+        failures.append(str(exc))
+    try:
+        whitelist = load_label_whitelist(root)
+    except GateConfigurationError as exc:
+        failures.append(str(exc))
+
+    registry_path = None
+    if registry_argument is not None:
+        registry_path = Path(registry_argument).expanduser()
+        if not registry_path.is_absolute():
+            registry_path = root / registry_path
+        registry_path = registry_path.resolve()
+        try:
+            registry_relative = registry_path.relative_to(root).as_posix()
+        except ValueError:
+            failures.append(
+                "gate-error: --registry must resolve inside --root (fail-closed)"
+            )
+            corpus_anchor = None
+        else:
+            corpus_anchor = registry_relative
+            try:
+                registry = load_registry(registry_path)
+            except GateConfigurationError as exc:
+                failures.append(str(exc))
+
+    try:
+        documents = read_sources(root, failures)
+        check_corpus_floor(documents, corpus_anchor, failures)
+        if rules:
+            denylist_hits = check_denylist(documents, rules, failures)
+        if account_slug:
+            personal_urls = check_personal_urls(documents, account_slug, registry, failures)
+        if registry is not None:
+            markdown, svg_documents = partition_documents(documents)
+            check_whitelist_staleness(documents, whitelist, failures)
+            root_links = check_missing_labels(markdown, registry, whitelist, failures)
+            svg_names = check_svg_state_sources(svg_documents, markdown, registry, failures)
+    except (KeyError, OSError, UnicodeError, ValueError) as exc:
+        failures.append("gate-error: publication checks could not complete: %s" % exc)
+
+    print("source files scanned : %d" % len(documents))
+    print("denylist matches     : %d" % denylist_hits)
+    print("personal URLs checked: %d" % personal_urls)
+    print("module links checked : %d" % root_links)
+    print("SVG names checked    : %d" % svg_names)
+    print("label whitelist      : %d" % len(whitelist))
+    if registry_argument is None:
+        for notice in SKIP_NOTICES:
+            print(notice)
+
+    if failures:
+        print("\nFAILED (%d):" % len(failures))
+        for failure in failures:
+            print("  - %s" % failure)
+        return 1
+    print("\nOK — publication gate passed with %d explicit label whitelist entries." % len(whitelist))
+    return 0
+
+
+def _selftest_check(condition, message):
+    if not condition:
+        raise RuntimeError("selftest failed: %s" % message)
+
+
+def _fixture_registry(account_slug="neutral-owner"):
+    return {
+        "languages": ["en", "ja"],
+        "map_repo": "example-org/map",
+        "status_labels": {"published": {"en": "published, MIT", "ja": "公開・MIT"}},
+        "modules": [
+            {"name": "Example Module", "repo": "example-org/example-module", "status": "published"}
+        ],
+        "retired_repos": [{"repo": account_slug + "/public-archive"}],
+    }
+
+
+def _capture_main(arguments):
+    output = io.StringIO()
+    with redirect_stdout(output):
+        status = main(arguments)
+    return status, output.getvalue()
+
+
+def _personal_url(account_slug, repository=None):
+    url = "https://github." + "com/" + account_slug
+    return url + "/" + repository if repository else url
+
+
+def selftest_policy_parsers():
+    with tempfile.TemporaryDirectory() as temporary:
+        root = Path(temporary)
+        try:
+            load_denylist(root)
+        except GateConfigurationError as exc:
+            _selftest_check(str(exc) == "gate-error: .publication-denylist missing/empty — a publication gate with no denylist proves nothing (fail-closed)", "missing denylist")
+        else:
+            raise RuntimeError("selftest failed: missing denylist accepted")
+        (root / DENYLIST_NAME).write_text("# comment\n\n", encoding="utf-8")
+        try:
+            load_denylist(root)
+        except GateConfigurationError as exc:
+            _selftest_check("missing/empty" in str(exc), "zero-rule denylist")
+        else:
+            raise RuntimeError("selftest failed: zero-rule denylist accepted")
+        for source, marker in (("broken\n", ":1 malformed rule"), ("name\t[\n", ":1 invalid regex")):
+            (root / DENYLIST_NAME).write_text(source, encoding="utf-8")
+            try:
+                load_denylist(root)
+            except GateConfigurationError as exc:
+                _selftest_check(marker in str(exc), "line-numbered policy error")
+            else:
+                raise RuntimeError("selftest failed: malformed denylist accepted")
+        (root / DENYLIST_NAME).write_text("marker\tprivate[\\t ]+marker\n", encoding="utf-8")
+        _selftest_check(len(load_denylist(root)) == 1, "first-tab denylist parser")
+        _selftest_check(load_label_whitelist(root) == frozenset(), "absent whitelist")
+        (root / WHITELIST_NAME).write_text("README.md\tapproved exact line\n", encoding="utf-8")
+        _selftest_check(("README.md", "approved exact line") in load_label_whitelist(root), "whitelist parser")
+        registry_path = root / "registry.json"
+        registry_path.write_text("[]\n", encoding="utf-8")
+        try:
+            load_registry(registry_path)
+        except GateConfigurationError as exc:
+            _selftest_check(
+                str(exc) == "gate-error: registry must be a JSON object",
+                "non-object registry error",
+            )
+        else:
+            raise RuntimeError("selftest failed: non-object registry accepted")
+
+
+def selftest_scanners():
+    rules = (("private marker", re.compile("private" + "[- ]marker", re.IGNORECASE)),)
+    failures = []
+    documents = {"README.md": "private%2Dmarker\n"}
+    _selftest_check(check_denylist(documents, rules, failures) == 1 and failures, "decoded denylist")
+    raw_failures = []
+    account_rule = (("account marker", re.compile("neutral-owner", re.IGNORECASE)),)
+    _selftest_check(check_denylist({"README.md": "neutral-owner"}, account_rule, raw_failures) == 1, "denylist raw account text")
+    email_failures = []
+    email_rule = (
+        (
+            "email address",
+            re.compile(r"\b[A-Z0-9._%+\-]+@[A-Z0-9.\-]+\.[A-Z]{2,}\b", re.IGNORECASE),
+        ),
+    )
+    _selftest_check(
+        check_denylist(
+            {"README.md": "bob@neutral-owner.com"}, email_rule, email_failures
+        )
+        == 1
+        and email_failures,
+        "slug-domain email remains visible to raw denylist",
+    )
+
+    no_registry_failures = []
+    count = check_personal_urls(
+        {"README.md": urllib.parse.quote(_personal_url("neutral-owner", "public-archive"))},
+        "neutral-owner",
+        None,
+        no_registry_failures,
+    )
+    _selftest_check(count == 1 and no_registry_failures, "registry-free personal URL any-hit")
+    registry = _fixture_registry()
+    allowed_failures = []
+    _selftest_check(
+        check_personal_urls(
+            {"README.md": _personal_url("neutral-owner", "public-archive")},
+            "neutral-owner",
+            registry,
+            allowed_failures,
+        ) == 1 and not allowed_failures,
+        "registry personal URL allowlist",
+    )
+    unknown_failures = []
+    _selftest_check(
+        check_personal_urls(
+            {"README.md": _personal_url("neutral-owner", "unlisted")},
+            "neutral-owner",
+            registry,
+            unknown_failures,
+        ) == 1 and unknown_failures,
+        "unknown personal repository",
+    )
+
+
+def selftest_registry_checks():
+    registry = _fixture_registry()
+    clean = {
+        "README.md": "[Example Module](https://github.com/example-org/example-module) — published, MIT\n"
+    }
+    failures = []
+    _selftest_check(check_missing_labels(clean, registry, frozenset(), failures) == 1 and not failures, "clean label")
+    missing = []
+    line = "[Example Module](https://github.com/example-org/example-module)"
+    _selftest_check(check_missing_labels({"README.md": line}, registry, frozenset(), missing) == 1 and missing, "missing label")
+    exempt = []
+    whitelist = frozenset((("README.md", line),))
+    _selftest_check(check_missing_labels({"README.md": line}, registry, whitelist, exempt) == 1 and not exempt, "exact whitelist")
+    stale = []
+    _selftest_check(check_whitelist_staleness({"README.md": line + " changed"}, whitelist, stale) == 1 and stale, "stale whitelist")
+    svg_failures = []
+    svg = {"assets/map.svg": "<svg><text>Example Module</text></svg>"}
+    _selftest_check(check_svg_state_sources(svg, clean, registry, svg_failures) >= 1 and not svg_failures, "clean SVG state")
+    missing_svg = []
+    _selftest_check(check_svg_state_sources(svg, {"README.md": line}, registry, missing_svg) >= 1 and missing_svg, "missing SVG state")
+
+
+def _materialize_fixture(source_dir, root, denylist_source):
+    (root / "README.md").write_text((source_dir / "README.fixture").read_text(encoding="utf-8"), encoding="utf-8")
+    (root / DENYLIST_NAME).write_text(denylist_source, encoding="utf-8")
+
+
+def selftest_end_to_end():
+    fixture_root = Path(__file__).resolve().parent / "fixtures"
+    denylist_source = (fixture_root / "sample.publication-denylist").read_text(encoding="utf-8")
+    with tempfile.TemporaryDirectory() as temporary:
+        root = Path(temporary)
+        _materialize_fixture(fixture_root / "clean-repo", root, denylist_source)
+        status, output = _capture_main(["--root", str(root), "--account-slug", "neutral-owner"])
+        _selftest_check(status == 0, "clean fixture main(): %r" % output)
+        _selftest_check(all(notice in output for notice in SKIP_NOTICES), "four registry skip notices")
+        missing_slug_status, missing_slug_output = _capture_main(["--root", str(root)])
+        _selftest_check(
+            missing_slug_status == 1
+            and "gate-error: --account-slug is required for publication URL checks (fail-closed)"
+            in missing_slug_output,
+            "missing account slug fails closed",
+        )
+
+    with tempfile.TemporaryDirectory() as temporary:
+        root = Path(temporary)
+        _materialize_fixture(fixture_root / "violating-repo", root, denylist_source)
+        status, output = _capture_main(["--root", str(root), "--account-slug", "neutral-owner"])
+        _selftest_check(status == 1 and "denylist:" in output, "violating fixture main()")
+
+    with tempfile.TemporaryDirectory() as temporary:
+        root = Path(temporary)
+        _materialize_fixture(fixture_root / "clean-repo", root, denylist_source)
+        copied_gate = root / "tools" / "check_publication_gate.py"
+        copied_gate.parent.mkdir(parents=True)
+        shutil.copyfile(Path(__file__), copied_gate)
+        status, output = _capture_main(["--root", str(root), "--account-slug", "neutral-owner"])
+        _selftest_check(status == 0 and "source files scanned : 2" in output, "copied gate self-scan: %r" % output)
+
+    with tempfile.TemporaryDirectory() as temporary:
+        root = Path(temporary)
+        _materialize_fixture(fixture_root / "clean-repo", root, denylist_source)
+        registry_path = root / "registry" / "modules.json"
+        registry_path.parent.mkdir(parents=True)
+        registry_path.write_text(json.dumps(_fixture_registry()), encoding="utf-8")
+        (root / "README.md").write_text(
+            "[Example Module](https://github.com/example-org/example-module) — published, MIT\n",
+            encoding="utf-8",
+        )
+        status, output = _capture_main(
+            ["--root", str(root), "--account-slug", "neutral-owner", "--registry", "registry/modules.json"]
+        )
+        _selftest_check(status == 0 and "notice:" not in output, "registry-backed main(): %r" % output)
+
+    with tempfile.TemporaryDirectory() as temporary, tempfile.TemporaryDirectory() as external:
+        root = Path(temporary)
+        _materialize_fixture(fixture_root / "clean-repo", root, denylist_source)
+        external_registry = Path(external) / "modules.json"
+        external_registry.write_text(json.dumps(_fixture_registry()), encoding="utf-8")
+        status, output = _capture_main(
+            [
+                "--root",
+                str(root),
+                "--account-slug",
+                "neutral-owner",
+                "--registry",
+                str(external_registry),
+            ]
+        )
+        _selftest_check(
+            status == 1
+            and "gate-error: --registry must resolve inside --root (fail-closed)" in output,
+            "external registry rejected without an empty corpus anchor",
+        )
+
+
+def run_selftests():
+    tests = (selftest_policy_parsers, selftest_scanners, selftest_registry_checks, selftest_end_to_end)
+    for test in tests:
+        test()
+        print("ok: %s" % test.__name__)
+    print("PASS (publication gate selftest)")
+    return 0
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--selftest", action="store_true", help="run embedded gate fixtures")
+    parser.add_argument("--root", type=Path, default=Path("."), help="repository checkout to inspect (default: .)")
+    parser.add_argument("--account-slug", default=None, help="personal account slug (required for normal runs)")
+    parser.add_argument("--registry", type=Path, default=None, help="optional publication registry JSON file")
+    args = parser.parse_args(argv)
+    if args.selftest:
+        return run_selftests()
+    return run_gate(args.root, args.account_slug, args.registry)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/templates/publication-gate/check_publication_gate.py
+++ b/templates/publication-gate/check_publication_gate.py
@@ -31,7 +31,7 @@ DENYLIST_NAME = ".publication-denylist"
 WHITELIST_NAME = ".publication-label-whitelist"
 ACCOUNT_SLUG = re.compile(r"^[A-Za-z0-9](?:[A-Za-z0-9-]{0,37})$")
 URL_CANDIDATE = re.compile(
-    r"(?<![A-Za-z0-9@._-])(?:https?://)?"
+    r"(?<![A-Za-z0-9@._-])(?:https?://(?:[A-Za-z0-9._~!$&'()*+,;=:%-]+@)?)?"
     r"(?:[A-Za-z0-9-]+\.)+[A-Za-z0-9-]+\.?(?::[0-9]+)?"
     r"(?:/[^\s<>'\"`()\[\]{}]*)?",
     re.IGNORECASE,
@@ -653,8 +653,26 @@ def _capture_main(arguments):
 
 
 def _fixture_personal_url(account_slug, repository=None):
-    url = "https://github." + "com/" + account_slug
+    url = "https://" + "github." + "com/" + account_slug
     return url + "/" + repository if repository else url
+
+
+def _fixture_module_link(repo="example-org/example-module"):
+    return "https://" + "github." + "com/" + repo
+
+
+def _fixture_module_line(with_status=True):
+    line = "[Example Module](" + _fixture_module_link() + ")"
+    return line + " — published, MIT" if with_status else line
+
+
+def _fixture_email(local_part, domain):
+    return local_part + "@" + domain
+
+
+def _fixture_userinfo_personal_url(account_slug, repository, username, host=None):
+    target_host = host or ("github." + "com")
+    return "https://" + username + "@" + target_host + "/" + account_slug + "/" + repository
 
 
 def selftest_policy_parsers():
@@ -756,11 +774,51 @@ def selftest_scanners():
     )
     _selftest_check(
         check_denylist(
-            {"README.md": "bob@neutral-owner.com"}, email_rule, email_failures
+            {"README.md": _fixture_email("bob", "neutral-owner." + "com")},
+            email_rule,
+            email_failures,
         )
         == 1
         and email_failures,
         "slug-domain email remains visible to raw denylist",
+    )
+    userinfo_failures = []
+    _selftest_check(
+        check_personal_urls(
+            {
+                "README.md": "See "
+                + _fixture_userinfo_personal_url(
+                    "neutral-owner", "private", "viewer"
+                )
+            },
+            "neutral-owner",
+            None,
+            userinfo_failures,
+        )
+        == 1
+        and "personal-url: README.md:1 references personal account repository neutral-owner/private"
+        in userinfo_failures[0],
+        "userinfo personal URL candidate",
+    )
+    clean_userinfo_failures = []
+    _selftest_check(
+        check_personal_urls(
+            {
+                "README.md": "See "
+                + _fixture_userinfo_personal_url(
+                    "neutral-owner",
+                    "private",
+                    "viewer",
+                    host="github." + "com.evil.invalid",
+                )
+            },
+            "neutral-owner",
+            None,
+            clean_userinfo_failures,
+        )
+        == 0
+        and not clean_userinfo_failures,
+        "userinfo clean host control",
     )
 
     normalized_failures = []
@@ -818,13 +876,11 @@ def selftest_scanners():
 
 def selftest_registry_checks():
     registry = _fixture_registry()
-    clean = {
-        "README.md": "[Example Module](https://github.com/example-org/example-module) — published, MIT\n"
-    }
+    clean = {"README.md": _fixture_module_line() + "\n"}
     failures = []
     _selftest_check(check_missing_labels(clean, registry, frozenset(), failures) == 1 and not failures, "clean label")
     missing = []
-    line = "[Example Module](https://github.com/example-org/example-module)"
+    line = _fixture_module_line(with_status=False)
     _selftest_check(check_missing_labels({"README.md": line}, registry, frozenset(), missing) == 1 and missing, "missing label")
     exempt = []
     whitelist = frozenset((("README.md", line),))
@@ -836,6 +892,13 @@ def selftest_registry_checks():
     _selftest_check(check_svg_state_sources(svg, clean, registry, svg_failures) >= 1 and not svg_failures, "clean SVG state")
     missing_svg = []
     _selftest_check(check_svg_state_sources(svg, {"README.md": line}, registry, missing_svg) >= 1 and missing_svg, "missing SVG state")
+
+
+SELFTEST_SOURCE_SCAN_DENYLIST = (
+    "email-address\t\\b[A-Z0-9._%+\\-]+@[A-Z0-9.\\-]+\\.[A-Z]{2,}\\b\n"
+    "github-url-ish\thttps?://(?:[A-Za-z0-9._~!$&'()*+,;=:%-]+@)?"
+    "(?:gist\\.)?github\\.(?:com|io)/[A-Za-z0-9._-]+(?:/[A-Za-z0-9._-]+)?\n"
+)
 
 
 def _materialize_fixture(root, readme=SELFTEST_CLEAN_README, denylist=SELFTEST_DENYLIST):
@@ -900,6 +963,15 @@ def selftest_end_to_end():
             whitespace_status == 1 and "gate-error: --account-slug" in whitespace_output,
             "whitespace account slug fails closed",
         )
+        invalid_slug_status, invalid_slug_output = _capture_main(
+            ["--root", str(root), "--account-slug", "foo/bar"]
+        )
+        _selftest_check(
+            invalid_slug_status == 1
+            and "gate-error: --account-slug must match ^[A-Za-z0-9](?:[A-Za-z0-9-]{0,37})$ (fail-closed)"
+            in invalid_slug_output,
+            "invalid account slug fails closed",
+        )
 
     with tempfile.TemporaryDirectory() as temporary:
         root = Path(temporary)
@@ -915,6 +987,15 @@ def selftest_end_to_end():
         shutil.copyfile(Path(__file__), copied_gate)
         status, output = _capture_main(["--root", str(root), "--account-slug", "neutral-owner"])
         _selftest_check(status == 0 and "source files scanned : 2" in output, "copied gate self-scan: %r" % output)
+        (root / DENYLIST_NAME).write_text(SELFTEST_SOURCE_SCAN_DENYLIST, encoding="utf-8")
+        source_scan_status, source_scan_output = _capture_main(
+            ["--root", str(root), "--account-slug", "neutral-owner"]
+        )
+        _selftest_check(
+            source_scan_status == 0
+            and "denylist matches     : 0" in source_scan_output,
+            "copied gate source scan denylist stays green: %r" % source_scan_output,
+        )
 
     with tempfile.TemporaryDirectory() as temporary:
         root = Path(temporary)
@@ -923,7 +1004,7 @@ def selftest_end_to_end():
         registry_path.parent.mkdir(parents=True)
         registry_path.write_text(json.dumps(_fixture_registry()), encoding="utf-8")
         (root / "README.md").write_text(
-            "[Example Module](https://github.com/example-org/example-module) — published, MIT\n",
+            _fixture_module_line() + "\n",
             encoding="utf-8",
         )
         status, output = _capture_main(

--- a/templates/publication-gate/check_publication_gate.py
+++ b/templates/publication-gate/check_publication_gate.py
@@ -24,12 +24,18 @@ import tempfile
 import urllib.parse
 
 
-SCANNED_SUFFIXES = frozenset((".md", ".json", ".py", ".yml", ".yaml", ".svg", ".sh"))
 EXCLUDED_DIRS = frozenset(
     (".git", ".omc", ".omx", ".venv", "venv", "node_modules", "__pycache__")
 )
 DENYLIST_NAME = ".publication-denylist"
 WHITELIST_NAME = ".publication-label-whitelist"
+ACCOUNT_SLUG = re.compile(r"^[A-Za-z0-9](?:[A-Za-z0-9-]{0,37})$")
+URL_CANDIDATE = re.compile(
+    r"(?<![A-Za-z0-9@._-])(?:https?://)?"
+    r"(?:[A-Za-z0-9-]+\.)+[A-Za-z0-9-]+\.?(?::[0-9]+)?"
+    r"(?:/[^\s<>'\"`()\[\]{}]*)?",
+    re.IGNORECASE,
+)
 LANG_SUFFIX = re.compile(r"\.(?P<lang>[a-z]{2}(?:-[a-z]{2})?)\.md$")
 SVG_TEXT_ELEMENT = re.compile(
     r"<(text|title|desc|metadata)\b[^>]*>(.*?)</\1\s*>", re.IGNORECASE | re.DOTALL
@@ -80,14 +86,34 @@ def _read_utf8(path, display_name):
         ) from exc
 
 
-def load_denylist(root):
+def _denylist_error_name(root, path):
+    try:
+        return path.relative_to(root).as_posix()
+    except ValueError:
+        return str(path)
+
+
+def denylist_path(root, denylist_argument=None):
+    if denylist_argument is None:
+        return root / DENYLIST_NAME
+    path = Path(denylist_argument).expanduser()
+    if not path.is_absolute():
+        path = root / path
+    return Path(os.path.abspath(str(path)))
+
+
+def load_denylist(root, denylist_argument=None):
     """Load NAME<TAB>REGEX policy, failing closed on absence or zero rules."""
-    path = root / DENYLIST_NAME
+    path = denylist_path(root, denylist_argument)
+    display_name = _denylist_error_name(root, path)
     if not path.is_file():
         raise GateConfigurationError(
-            "gate-error: .publication-denylist missing/empty — a publication gate with no denylist proves nothing (fail-closed)"
+            "gate-error: %s missing/empty — a publication gate with no denylist proves nothing (fail-closed)"
+            % display_name
         )
-    text = _read_utf8(path, DENYLIST_NAME)
+    text = _read_utf8(path, display_name)
+    if text.startswith("\ufeff"):
+        text = text[1:]
     rules = []
     for number, line in enumerate(text.splitlines(), 1):
         if not line.strip() or line.startswith("#"):
@@ -95,25 +121,41 @@ def load_denylist(root):
         if "\t" not in line:
             raise GateConfigurationError(
                 "gate-error: %s:%d malformed rule: expected NAME<TAB>REGEX"
-                % (DENYLIST_NAME, number)
+                % (display_name, number)
             )
         name, expression = line.split("\t", 1)
-        if not name or not expression:
+        if not name or name.isspace() or any(character.isspace() for character in name):
             raise GateConfigurationError(
-                "gate-error: %s:%d malformed rule: NAME and REGEX must be non-empty"
-                % (DENYLIST_NAME, number)
+                "gate-error: %s:%d malformed rule: NAME must be non-empty and contain no whitespace"
+                % (display_name, number)
+            )
+        if not expression:
+            raise GateConfigurationError(
+                "gate-error: %s:%d malformed rule: REGEX must be non-empty"
+                % (display_name, number)
+            )
+        if "\t" in expression:
+            raise GateConfigurationError(
+                "gate-error: %s:%d malformed rule: extra TAB fields are not allowed; write \\t explicitly in REGEX"
+                % (display_name, number)
+            )
+        if expression != expression.strip():
+            raise GateConfigurationError(
+                "gate-error: %s:%d malformed rule: REGEX must not have leading/trailing whitespace; write \\s or [ ] explicitly"
+                % (display_name, number)
             )
         try:
             pattern = re.compile(expression, re.IGNORECASE)
         except re.error as exc:
             raise GateConfigurationError(
                 "gate-error: %s:%d invalid regex for %s: %s"
-                % (DENYLIST_NAME, number, name, exc)
+                % (display_name, number, name, exc)
             ) from exc
         rules.append((name, pattern))
     if not rules:
         raise GateConfigurationError(
-            "gate-error: .publication-denylist missing/empty — a publication gate with no denylist proves nothing (fail-closed)"
+            "gate-error: %s missing/empty — a publication gate with no denylist proves nothing (fail-closed)"
+            % display_name
         )
     return tuple(rules)
 
@@ -154,61 +196,86 @@ def _git_paths(root):
             stderr=subprocess.PIPE,
             check=False,
         )
-    except OSError:
-        return None
+    except OSError as exc:
+        raise GateConfigurationError(
+            "gate-error: git enumeration failed for a root containing .git: %s" % exc
+        ) from exc
     if result.returncode != 0:
-        return None
+        detail = result.stderr.decode("utf-8", errors="replace").strip()
+        raise GateConfigurationError(
+            "gate-error: git enumeration failed for a root containing .git: %s"
+            % (detail or "git ls-files exited %d" % result.returncode)
+        )
     paths = []
     for relative_bytes in filter(None, result.stdout.split(b"\0")):
         try:
             relative = relative_bytes.decode("utf-8")
-        except UnicodeError:
-            return None
+        except UnicodeError as exc:
+            raise GateConfigurationError(
+                "gate-error: git enumeration returned a non-UTF-8 path: %s" % exc
+            ) from exc
         paths.append(root / relative)
     return paths
 
 
-def iter_source_paths(root):
-    paths = _git_paths(root)
-    if paths is None:
-        paths = root.rglob("*")
-    policy_path = root / DENYLIST_NAME
+def _contains_git_entry(root):
+    return os.path.lexists(str(root / ".git"))
+
+
+def iter_source_paths(root, excluded_policy_path):
+    """Return (paths, mode); only the non-git fallback applies EXCLUDED_DIRS."""
+    git_mode = _contains_git_entry(root)
+    paths = _git_paths(root) if git_mode else root.rglob("*")
+    policy_key = os.path.abspath(str(excluded_policy_path))
     selected = []
     for path in paths:
         try:
             relative = path.relative_to(root)
         except ValueError:
             continue
-        if any(part in EXCLUDED_DIRS for part in relative.parts[:-1]):
+        if not git_mode and any(part in EXCLUDED_DIRS for part in relative.parts[:-1]):
             continue
-        if path == policy_path or path.suffix.lower() not in SCANNED_SUFFIXES:
+        if os.path.abspath(str(path)) == policy_key:
             continue
         selected.append(path)
-    return iter(sorted(selected, key=lambda candidate: candidate.relative_to(root).as_posix()))
+    ordered = sorted(selected, key=lambda candidate: candidate.relative_to(root).as_posix())
+    return ordered, "git" if git_mode else "rglob-fallback"
 
 
-def read_sources(root, failures):
+def read_sources(root, failures, excluded_policy_path):
     documents = {}
-    for path in iter_source_paths(root):
+    binary_skipped = 0
+    symlinks_skipped = 0
+    paths, enumeration_mode = iter_source_paths(root, excluded_policy_path)
+    for path in paths:
         relative = path.relative_to(root).as_posix()
         try:
             if path.is_symlink():
-                documents[relative] = os.readlink(path)
+                if enumeration_mode == "git":
+                    documents[relative] = os.readlink(path)
+                else:
+                    symlinks_skipped += 1
                 continue
-            if not stat.S_ISREG(os.lstat(path).st_mode):
+            mode = os.lstat(path).st_mode
+            if stat.S_ISDIR(mode):
+                continue
+            if not stat.S_ISREG(mode):
                 failures.append("source-read: %s is not a regular file" % relative)
                 continue
-            documents[relative] = path.read_text(encoding="utf-8")
-        except (OSError, UnicodeError) as exc:
-            failures.append("source-read: %s could not be read as UTF-8: %s" % (relative, exc))
-    return documents
+            try:
+                documents[relative] = path.read_bytes().decode("utf-8")
+            except UnicodeDecodeError:
+                binary_skipped += 1
+        except OSError as exc:
+            failures.append("source-read: %s could not be read: %s" % (relative, exc))
+    return documents, enumeration_mode, binary_skipped, symlinks_skipped
 
 
 def check_denylist(documents, rules, failures):
     checked = 0
     for path, text in documents.items():
         reported = set()
-        for view in scan_views(text):
+        for view_index, view in enumerate(scan_views(text)):
             for description, pattern in rules:
                 for match in pattern.finditer(view):
                     finding = (line_number(view, match.start()), description)
@@ -216,19 +283,35 @@ def check_denylist(documents, rules, failures):
                         continue
                     reported.add(finding)
                     failures.append(
-                        "denylist: %s:%d contains %s" % (path, finding[0], description)
+                        "denylist: %s:%d contains %s%s"
+                        % (
+                            path,
+                            finding[0],
+                            description,
+                            "" if view_index == 0 else " (decoded view)",
+                        )
                     )
                     checked += 1
     return checked
 
 
-def personal_url_pattern(account_slug):
-    return re.compile(
-        r"(?<![A-Za-z0-9.-])(?:www\.)?github\.com/"
-        + re.escape(account_slug)
-        + r"(?:/(?P<repo>[A-Za-z0-9_.-]*[A-Za-z0-9_-])(?=$|[^A-Za-z0-9_-])|/?(?![A-Za-z0-9_.-]))",
-        re.IGNORECASE,
-    )
+def _personal_url(candidate, account_slug):
+    candidate = candidate.rstrip(".,;:!?")
+    parsed = urllib.parse.urlsplit(candidate if "://" in candidate else "//" + candidate)
+    host = (parsed.hostname or "").casefold()
+    if host.endswith("."):
+        host = host[:-1]
+    if host.startswith("www."):
+        host = host[4:]
+    segments = [urllib.parse.unquote(segment) for segment in parsed.path.split("/") if segment]
+    folded_slug = account_slug.casefold()
+    if host == "github.com" and segments and segments[0].casefold() == folded_slug:
+        return segments[1] if len(segments) > 1 else None
+    if host == "gist.github.com" and segments and segments[0].casefold() == folded_slug:
+        return None
+    if host == folded_slug + ".github.io":
+        return account_slug + ".github.io"
+    return False
 
 
 def registry_allowlist(registry):
@@ -240,35 +323,37 @@ def registry_allowlist(registry):
 
 
 def check_personal_urls(documents, account_slug, registry, failures):
-    pattern = personal_url_pattern(account_slug)
     allowlist = registry_allowlist(registry) if registry is not None else None
     checked = 0
     for path, text in documents.items():
         reported = set()
-        for view in scan_views(text):
-            for match in pattern.finditer(view):
+        for view_index, view in enumerate(scan_views(text)):
+            for match in URL_CANDIDATE.finditer(view):
+                repo_name = _personal_url(match.group(0), account_slug)
+                if repo_name is False:
+                    continue
                 number = line_number(view, match.start())
-                repo_name = match.group("repo")
                 repo = "%s/%s" % (account_slug, repo_name) if repo_name else account_slug
                 finding = (number, repo.casefold())
                 if finding in reported:
                     continue
                 reported.add(finding)
                 checked += 1
+                view_marker = "" if view_index == 0 else " (decoded view)"
                 if repo_name is None:
                     failures.append(
-                        "personal-url: %s:%d references personal account profile %s"
-                        % (path, number, account_slug)
+                        "personal-url: %s:%d references personal account profile %s%s"
+                        % (path, number, account_slug, view_marker)
                     )
                 elif allowlist is None:
                     failures.append(
-                        "personal-url: %s:%d references personal account repository %s"
-                        % (path, number, repo)
+                        "personal-url: %s:%d references personal account repository %s%s"
+                        % (path, number, repo, view_marker)
                     )
                 elif repo.casefold() not in allowlist:
                     failures.append(
-                        "personal-url: %s:%d references unknown repository %s"
-                        % (path, number, repo)
+                        "personal-url: %s:%d references unknown repository %s%s"
+                        % (path, number, repo, view_marker)
                     )
     return checked
 
@@ -430,7 +515,7 @@ SKIP_NOTICES = (
 )
 
 
-def run_gate(root, account_slug, registry_argument=None):
+def run_gate(root, account_slug, registry_argument=None, denylist_argument=None):
     root = Path(root).expanduser().resolve()
     failures = []
     documents = {}
@@ -443,12 +528,22 @@ def run_gate(root, account_slug, registry_argument=None):
     personal_urls = 0
     root_links = 0
     svg_names = 0
+    enumeration_mode = "git" if _contains_git_entry(root) else "rglob-fallback"
+    binary_skipped = 0
+    symlinks_skipped = 0
+    policy_path = denylist_path(root, denylist_argument)
 
-    if not account_slug:
+    normalized_slug = account_slug.strip() if account_slug is not None else ""
+    if not normalized_slug:
         failures.append("gate-error: --account-slug is required for publication URL checks (fail-closed)")
+    elif not ACCOUNT_SLUG.fullmatch(normalized_slug):
+        failures.append(
+            "gate-error: --account-slug must match ^[A-Za-z0-9](?:[A-Za-z0-9-]{0,37})$ (fail-closed)"
+        )
+        normalized_slug = ""
 
     try:
-        rules = load_denylist(root)
+        rules = load_denylist(root, denylist_argument)
     except GateConfigurationError as exc:
         failures.append(str(exc))
     try:
@@ -477,21 +572,30 @@ def run_gate(root, account_slug, registry_argument=None):
                 failures.append(str(exc))
 
     try:
-        documents = read_sources(root, failures)
+        documents, enumeration_mode, binary_skipped, symlinks_skipped = read_sources(
+            root, failures, policy_path
+        )
         check_corpus_floor(documents, corpus_anchor, failures)
         if rules:
             denylist_hits = check_denylist(documents, rules, failures)
-        if account_slug:
-            personal_urls = check_personal_urls(documents, account_slug, registry, failures)
+        if normalized_slug:
+            personal_urls = check_personal_urls(documents, normalized_slug, registry, failures)
         if registry is not None:
             markdown, svg_documents = partition_documents(documents)
             check_whitelist_staleness(documents, whitelist, failures)
             root_links = check_missing_labels(markdown, registry, whitelist, failures)
             svg_names = check_svg_state_sources(svg_documents, markdown, registry, failures)
+    except GateConfigurationError as exc:
+        failures.append(str(exc))
     except (KeyError, OSError, UnicodeError, ValueError) as exc:
         failures.append("gate-error: publication checks could not complete: %s" % exc)
 
+    print("enumeration: %s" % enumeration_mode)
     print("source files scanned : %d" % len(documents))
+    print("binary files skipped: %d" % binary_skipped)
+    if enumeration_mode == "rglob-fallback":
+        print("symlinks skipped: %d" % symlinks_skipped)
+    print("denylist rules loaded : %d" % len(rules))
     print("denylist matches     : %d" % denylist_hits)
     print("personal URLs checked: %d" % personal_urls)
     print("module links checked : %d" % root_links)
@@ -510,7 +614,21 @@ def run_gate(root, account_slug, registry_argument=None):
     return 0
 
 
+SELFTEST_DENYLIST = (
+    "# Embedded policy fixture.\n"
+    "private-marker\tacme[-_ ]" "secret\n"
+    "private-host\tprivate\\.example\\.invalid\n"
+)
+SELFTEST_CLEAN_README = "# Public project\n\nPublication-safe example content.\n"
+SELFTEST_VIOLATING_README = (
+    "# Internal project\n\nThis exposes an acme-" "secret marker.\n"
+)
+SELFTEST_ASSERTIONS = 0
+
+
 def _selftest_check(condition, message):
+    global SELFTEST_ASSERTIONS
+    SELFTEST_ASSERTIONS += 1
     if not condition:
         raise RuntimeError("selftest failed: %s" % message)
 
@@ -534,7 +652,7 @@ def _capture_main(arguments):
     return status, output.getvalue()
 
 
-def _personal_url(account_slug, repository=None):
+def _fixture_personal_url(account_slug, repository=None):
     url = "https://github." + "com/" + account_slug
     return url + "/" + repository if repository else url
 
@@ -545,7 +663,11 @@ def selftest_policy_parsers():
         try:
             load_denylist(root)
         except GateConfigurationError as exc:
-            _selftest_check(str(exc) == "gate-error: .publication-denylist missing/empty — a publication gate with no denylist proves nothing (fail-closed)", "missing denylist")
+            _selftest_check(
+                str(exc)
+                == "gate-error: .publication-denylist missing/empty — a publication gate with no denylist proves nothing (fail-closed)",
+                "missing denylist",
+            )
         else:
             raise RuntimeError("selftest failed: missing denylist accepted")
         (root / DENYLIST_NAME).write_text("# comment\n\n", encoding="utf-8")
@@ -555,7 +677,16 @@ def selftest_policy_parsers():
             _selftest_check("missing/empty" in str(exc), "zero-rule denylist")
         else:
             raise RuntimeError("selftest failed: zero-rule denylist accepted")
-        for source, marker in (("broken\n", ":1 malformed rule"), ("name\t[\n", ":1 invalid regex")):
+        malformed = (
+            ("broken\n", ":1 malformed rule"),
+            ("name\t[\n", ":1 invalid regex"),
+            ("bad name\tmarker\n", ":1 malformed rule"),
+            ("\tmarker\n", ":1 malformed rule"),
+            ("bad\tname\tmarker\n", ":1 malformed rule"),
+            ("name\t marker\n", "write \\s or [ ] explicitly"),
+            ("name\tmarker \n", "write \\s or [ ] explicitly"),
+        )
+        for source, marker in malformed:
             (root / DENYLIST_NAME).write_text(source, encoding="utf-8")
             try:
                 load_denylist(root)
@@ -563,8 +694,11 @@ def selftest_policy_parsers():
                 _selftest_check(marker in str(exc), "line-numbered policy error")
             else:
                 raise RuntimeError("selftest failed: malformed denylist accepted")
-        (root / DENYLIST_NAME).write_text("marker\tprivate[\\t ]+marker\n", encoding="utf-8")
-        _selftest_check(len(load_denylist(root)) == 1, "first-tab denylist parser")
+        (root / DENYLIST_NAME).write_text(
+            "\ufeff# BOM-prefixed comment\nmarker\tprivate(?:\\t|[ ])+marker\n",
+            encoding="utf-8",
+        )
+        _selftest_check(len(load_denylist(root)) == 1, "BOM comment and explicit whitespace regex")
         _selftest_check(load_label_whitelist(root) == frozenset(), "absent whitelist")
         (root / WHITELIST_NAME).write_text("README.md\tapproved exact line\n", encoding="utf-8")
         _selftest_check(("README.md", "approved exact line") in load_label_whitelist(root), "whitelist parser")
@@ -585,7 +719,31 @@ def selftest_scanners():
     rules = (("private marker", re.compile("private" + "[- ]marker", re.IGNORECASE)),)
     failures = []
     documents = {"README.md": "private%2Dmarker\n"}
-    _selftest_check(check_denylist(documents, rules, failures) == 1 and failures, "decoded denylist")
+    _selftest_check(
+        check_denylist(documents, rules, failures) == 1
+        and "(decoded view)" in failures[0],
+        "decoded denylist marker",
+    )
+    raw_line_failures = []
+    _selftest_check(
+        check_denylist(
+            {"README.md": "safe\nprivate-marker\n"}, rules, raw_line_failures
+        )
+        == 1
+        and "README.md:2" in raw_line_failures[0]
+        and "(decoded view)" not in raw_line_failures[0],
+        "raw-view line number",
+    )
+    decoded_line_failures = []
+    _selftest_check(
+        check_denylist(
+            {"README.md": "safe%0Aprivate%2Dmarker\n"}, rules, decoded_line_failures
+        )
+        == 1
+        and "README.md:2" in decoded_line_failures[0]
+        and "(decoded view)" in decoded_line_failures[0],
+        "decoded-view line number",
+    )
     raw_failures = []
     account_rule = (("account marker", re.compile("neutral-owner", re.IGNORECASE)),)
     _selftest_check(check_denylist({"README.md": "neutral-owner"}, account_rule, raw_failures) == 1, "denylist raw account text")
@@ -605,9 +763,31 @@ def selftest_scanners():
         "slug-domain email remains visible to raw denylist",
     )
 
+    normalized_failures = []
+    normalized_documents = {
+        "README.md": "\n".join(
+            (
+                "https://github." "com:443/neutral-owner/x",
+                "https://github." "com./neutral-owner/x",
+                "https://gist.github." "com/neutral-owner/x",
+                "https://neutral-owner.github." "io/page",
+                "https://not-neutral-owner.github." "io/page",
+                "https://github." "com.evil.invalid/neutral-owner/x",
+            )
+        )
+    }
+    _selftest_check(
+        check_personal_urls(
+            normalized_documents, "neutral-owner", None, normalized_failures
+        )
+        == 4
+        and len(normalized_failures) == 4,
+        "normalized personal URL hosts and unrelated-host negatives",
+    )
+
     no_registry_failures = []
     count = check_personal_urls(
-        {"README.md": urllib.parse.quote(_personal_url("neutral-owner", "public-archive"))},
+        {"README.md": urllib.parse.quote(_fixture_personal_url("neutral-owner", "public-archive"))},
         "neutral-owner",
         None,
         no_registry_failures,
@@ -617,7 +797,7 @@ def selftest_scanners():
     allowed_failures = []
     _selftest_check(
         check_personal_urls(
-            {"README.md": _personal_url("neutral-owner", "public-archive")},
+            {"README.md": _fixture_personal_url("neutral-owner", "public-archive") + "."},
             "neutral-owner",
             registry,
             allowed_failures,
@@ -627,7 +807,7 @@ def selftest_scanners():
     unknown_failures = []
     _selftest_check(
         check_personal_urls(
-            {"README.md": _personal_url("neutral-owner", "unlisted")},
+            {"README.md": _fixture_personal_url("neutral-owner", "unlisted")},
             "neutral-owner",
             registry,
             unknown_failures,
@@ -658,20 +838,54 @@ def selftest_registry_checks():
     _selftest_check(check_svg_state_sources(svg, {"README.md": line}, registry, missing_svg) >= 1 and missing_svg, "missing SVG state")
 
 
-def _materialize_fixture(source_dir, root, denylist_source):
-    (root / "README.md").write_text((source_dir / "README.fixture").read_text(encoding="utf-8"), encoding="utf-8")
-    (root / DENYLIST_NAME).write_text(denylist_source, encoding="utf-8")
+def _materialize_fixture(root, readme=SELFTEST_CLEAN_README, denylist=SELFTEST_DENYLIST):
+    (root / "README.md").write_text(readme, encoding="utf-8")
+    (root / DENYLIST_NAME).write_text(denylist, encoding="utf-8")
+
+
+def _git(arguments, root):
+    result = subprocess.run(
+        ["git"] + list(arguments),
+        cwd=str(root),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    _selftest_check(
+        result.returncode == 0,
+        "git %s: %s"
+        % (" ".join(arguments), result.stderr.decode("utf-8", errors="replace")),
+    )
+
+
+def _initialize_git_fixture(root, paths):
+    _git(["init", "-q"], root)
+    _git(["add", "-f", "--"] + list(paths), root)
 
 
 def selftest_end_to_end():
-    fixture_root = Path(__file__).resolve().parent / "fixtures"
-    denylist_source = (fixture_root / "sample.publication-denylist").read_text(encoding="utf-8")
     with tempfile.TemporaryDirectory() as temporary:
         root = Path(temporary)
-        _materialize_fixture(fixture_root / "clean-repo", root, denylist_source)
+        _materialize_fixture(root)
+        (root / ".env").write_text("PUBLIC_VALUE=example\n", encoding="utf-8")
+        (root / "LICENSE").write_text("Example license\n", encoding="utf-8")
+        (root / "Dockerfile").write_text("FROM scratch\n", encoding="utf-8")
+        (root / "notes.txt").write_text("safe notes\n", encoding="utf-8")
+        (root / "extensionless").write_text("safe\n", encoding="utf-8")
+        (root / "image.bin").write_bytes(b"\xff\xfe\x00")
+        (root / "node_modules").mkdir()
+        (root / "node_modules" / "fallback-excluded.md").write_text(
+            "acme-" "secret\n", encoding="utf-8"
+        )
+        os.symlink("README.md", root / "readme-link")
         status, output = _capture_main(["--root", str(root), "--account-slug", "neutral-owner"])
         _selftest_check(status == 0, "clean fixture main(): %r" % output)
         _selftest_check(all(notice in output for notice in SKIP_NOTICES), "four registry skip notices")
+        _selftest_check("enumeration: rglob-fallback" in output, "fallback enumeration summary")
+        _selftest_check("source files scanned : 6" in output, "all UTF-8 suffixes and extensionless files scanned")
+        _selftest_check("binary files skipped: 1" in output, "binary summary")
+        _selftest_check("symlinks skipped: 1" in output, "fallback symlink summary")
+        _selftest_check("denylist rules loaded : 2" in output, "denylist rule summary")
         missing_slug_status, missing_slug_output = _capture_main(["--root", str(root)])
         _selftest_check(
             missing_slug_status == 1
@@ -679,16 +893,23 @@ def selftest_end_to_end():
             in missing_slug_output,
             "missing account slug fails closed",
         )
+        whitespace_status, whitespace_output = _capture_main(
+            ["--root", str(root), "--account-slug", " "]
+        )
+        _selftest_check(
+            whitespace_status == 1 and "gate-error: --account-slug" in whitespace_output,
+            "whitespace account slug fails closed",
+        )
 
     with tempfile.TemporaryDirectory() as temporary:
         root = Path(temporary)
-        _materialize_fixture(fixture_root / "violating-repo", root, denylist_source)
+        _materialize_fixture(root, SELFTEST_VIOLATING_README)
         status, output = _capture_main(["--root", str(root), "--account-slug", "neutral-owner"])
         _selftest_check(status == 1 and "denylist:" in output, "violating fixture main()")
 
     with tempfile.TemporaryDirectory() as temporary:
         root = Path(temporary)
-        _materialize_fixture(fixture_root / "clean-repo", root, denylist_source)
+        _materialize_fixture(root)
         copied_gate = root / "tools" / "check_publication_gate.py"
         copied_gate.parent.mkdir(parents=True)
         shutil.copyfile(Path(__file__), copied_gate)
@@ -697,7 +918,7 @@ def selftest_end_to_end():
 
     with tempfile.TemporaryDirectory() as temporary:
         root = Path(temporary)
-        _materialize_fixture(fixture_root / "clean-repo", root, denylist_source)
+        _materialize_fixture(root)
         registry_path = root / "registry" / "modules.json"
         registry_path.parent.mkdir(parents=True)
         registry_path.write_text(json.dumps(_fixture_registry()), encoding="utf-8")
@@ -712,7 +933,7 @@ def selftest_end_to_end():
 
     with tempfile.TemporaryDirectory() as temporary, tempfile.TemporaryDirectory() as external:
         root = Path(temporary)
-        _materialize_fixture(fixture_root / "clean-repo", root, denylist_source)
+        _materialize_fixture(root)
         external_registry = Path(external) / "modules.json"
         external_registry.write_text(json.dumps(_fixture_registry()), encoding="utf-8")
         status, output = _capture_main(
@@ -731,13 +952,168 @@ def selftest_end_to_end():
             "external registry rejected without an empty corpus anchor",
         )
 
+    with tempfile.TemporaryDirectory() as temporary:
+        root = Path(temporary)
+        _materialize_fixture(root)
+        (root / ".gitignore").write_text("node_modules/\n*.txt\n", encoding="utf-8")
+        (root / "node_modules").mkdir()
+        (root / "node_modules" / "x.md").write_text(
+            "acme-" "secret\n", encoding="utf-8"
+        )
+        (root / "published.txt").write_text("acme-" "secret\n", encoding="utf-8")
+        _initialize_git_fixture(
+            root,
+            ("README.md", DENYLIST_NAME, ".gitignore", "node_modules/x.md", "published.txt"),
+        )
+        status, output = _capture_main(
+            ["--root", str(root), "--account-slug", "neutral-owner"]
+        )
+        _selftest_check(
+            status == 1
+            and "enumeration: git" in output
+            and "denylist: node_modules/x.md:1" in output
+            and "denylist: published.txt:1" in output,
+            "git mode scans committed formerly-excluded and .txt files: %r" % output,
+        )
+
+    with tempfile.TemporaryDirectory() as temporary:
+        root = Path(temporary)
+        _materialize_fixture(root)
+        (root / "binary.dat").write_bytes(b"\x80\x81\x82")
+        _initialize_git_fixture(root, ("README.md", DENYLIST_NAME, "binary.dat"))
+        status, output = _capture_main(
+            ["--root", str(root), "--account-slug", "neutral-owner"]
+        )
+        _selftest_check(
+            status == 0
+            and "enumeration: git" in output
+            and "binary files skipped: 1" in output,
+            "git binary is skipped once and counted: %r" % output,
+        )
+
+    with tempfile.TemporaryDirectory() as temporary:
+        root = Path(temporary)
+        _materialize_fixture(root)
+        os.symlink("https://github." "com/neutral-owner/private", root / "published-link")
+        _initialize_git_fixture(root, ("README.md", DENYLIST_NAME, "published-link"))
+        status, output = _capture_main(
+            ["--root", str(root), "--account-slug", "neutral-owner"]
+        )
+        _selftest_check(
+            status == 1
+            and "personal-url: published-link:1" in output
+            and "symlinks skipped:" not in output,
+            "git symlink readlink text is scanned: %r" % output,
+        )
+
+    with tempfile.TemporaryDirectory() as temporary:
+        root = Path(temporary)
+        _materialize_fixture(
+            root,
+            "Contact bob@" "neutral-owner.com\n",
+            "email-address\t\\b[A-Z0-9._%+\\-]+@[A-Z0-9.\\-]+\\.[A-Z]{2,}\\b\n",
+        )
+        status, output = _capture_main(
+            ["--root", str(root), "--account-slug", "neutral-owner"]
+        )
+        _selftest_check(
+            status == 1 and "denylist: README.md:1 contains email-address" in output,
+            "main-level slug-domain email denylist: %r" % output,
+        )
+
+    with tempfile.TemporaryDirectory() as temporary:
+        root = Path(temporary)
+        _materialize_fixture(
+            root, "See https://gist.github." "com/neutral-owner/example\n"
+        )
+        status, output = _capture_main(
+            ["--root", str(root), "--account-slug", "neutral-owner"]
+        )
+        _selftest_check(
+            status == 1 and "personal-url: README.md:1" in output,
+            "main-level personal URL without registry: %r" % output,
+        )
+
+    with tempfile.TemporaryDirectory() as temporary:
+        root = Path(temporary)
+        _materialize_fixture(root)
+        (root / "README.md").unlink()
+        (root / "safe.txt").write_text("safe\n", encoding="utf-8")
+        status, output = _capture_main(
+            ["--root", str(root), "--account-slug", "neutral-owner"]
+        )
+        _selftest_check(
+            status == 1 and "corpus-floor: README.md was not among scanned documents" in output,
+            "main-level corpus floor: %r" % output,
+        )
+
+    with tempfile.TemporaryDirectory() as temporary:
+        root = Path(temporary)
+        _materialize_fixture(root)
+        (root / ".git").mkdir()
+        status, output = _capture_main(
+            ["--root", str(root), "--account-slug", "neutral-owner"]
+        )
+        _selftest_check(
+            status == 1
+            and "enumeration: git" in output
+            and "gate-error: git enumeration failed" in output
+            and "denylist rules loaded : 2" in output,
+            "broken .git fails closed without fallback: %r" % output,
+        )
+
+    with tempfile.TemporaryDirectory() as temporary:
+        root = Path(temporary)
+        (root / "policies").mkdir()
+        explicit = root / "policies" / "secret-rules.txt"
+        explicit.write_text(SELFTEST_DENYLIST, encoding="utf-8")
+        (root / "README.md").write_text(SELFTEST_CLEAN_README, encoding="utf-8")
+        status, output = _capture_main(
+            [
+                "--root",
+                str(root),
+                "--account-slug",
+                "neutral-owner",
+                "--denylist",
+                "policies/secret-rules.txt",
+            ]
+        )
+        _selftest_check(
+            status == 0
+            and "source files scanned : 1" in output
+            and "denylist rules loaded : 2" in output,
+            "explicit in-root denylist is path-excluded: %r" % output,
+        )
+
+    if not os.environ.get("PUBLICATION_GATE_SELFTEST_COPY_PROBE"):
+        with tempfile.TemporaryDirectory() as temporary:
+            copied_gate = Path(temporary) / "check_publication_gate.py"
+            shutil.copyfile(Path(__file__), copied_gate)
+            environment = dict(os.environ)
+            environment["PUBLICATION_GATE_SELFTEST_COPY_PROBE"] = "1"
+            result = subprocess.run(
+                [sys.executable, "-B", str(copied_gate), "--selftest"],
+                cwd=temporary,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                env=environment,
+                check=False,
+                text=True,
+            )
+            _selftest_check(
+                result.returncode == 0 and "PASS (publication gate selftest" in result.stdout,
+                "copied-single-file selftest: %r" % result.stdout,
+            )
+
 
 def run_selftests():
+    global SELFTEST_ASSERTIONS
+    SELFTEST_ASSERTIONS = 0
     tests = (selftest_policy_parsers, selftest_scanners, selftest_registry_checks, selftest_end_to_end)
     for test in tests:
         test()
         print("ok: %s" % test.__name__)
-    print("PASS (publication gate selftest)")
+    print("PASS (publication gate selftest; assertions: %d)" % SELFTEST_ASSERTIONS)
     return 0
 
 
@@ -747,10 +1123,16 @@ def main(argv=None):
     parser.add_argument("--root", type=Path, default=Path("."), help="repository checkout to inspect (default: .)")
     parser.add_argument("--account-slug", default=None, help="personal account slug (required for normal runs)")
     parser.add_argument("--registry", type=Path, default=None, help="optional publication registry JSON file")
+    parser.add_argument(
+        "--denylist",
+        type=Path,
+        default=None,
+        help="denylist policy file (default: <root>/.publication-denylist)",
+    )
     args = parser.parse_args(argv)
     if args.selftest:
         return run_selftests()
-    return run_gate(args.root, args.account_slug, args.registry)
+    return run_gate(args.root, args.account_slug, args.registry, args.denylist)
 
 
 if __name__ == "__main__":

--- a/templates/publication-gate/fixtures/clean-repo/README.fixture
+++ b/templates/publication-gate/fixtures/clean-repo/README.fixture
@@ -1,0 +1,3 @@
+# Public project
+
+This fixture contains only publication-safe example content.

--- a/templates/publication-gate/fixtures/sample.publication-denylist
+++ b/templates/publication-gate/fixtures/sample.publication-denylist
@@ -1,0 +1,3 @@
+# Copy this file to the repository root as .publication-denylist and customize it.
+private marker	acme[-_ ]secret
+private host	private\.example\.invalid

--- a/templates/publication-gate/fixtures/sample.publication-denylist
+++ b/templates/publication-gate/fixtures/sample.publication-denylist
@@ -1,3 +1,3 @@
 # Copy this file to the repository root as .publication-denylist and customize it.
-private marker	acme[-_ ]secret
-private host	private\.example\.invalid
+private-marker	acme[-_ ]secret
+private-host	private\.example\.invalid

--- a/templates/publication-gate/fixtures/violating-repo/README.fixture
+++ b/templates/publication-gate/fixtures/violating-repo/README.fixture
@@ -1,0 +1,3 @@
+# Internal project
+
+This fixture exposes an acme-secret marker and must fail the publication gate.


### PR DESCRIPTION
Closes #83 (W0-5). Campaign tracking: https://github.com/caty-ai/family-os/issues/56

## Why
公開ゲートが family-os / org .github の2コピーで乖離進行中（実測 888 vs 155 行）。handbook templates に正本を置き、denylist を `.publication-denylist` に外出しして Tier 2 へ配布可能にする。

## What
- 正本選定: family-os 系ベース + org 系から end-to-end selftest（自己スキャン回帰込み）・非 git fallback を移植
- **分析で発見したバグ修正**: slug マスキングが denylist パスの前に走り、slug ドメインのメール検出を無効化していた → masking は personal-url 検査内のみに限定
- denylist 外出し: `NAME<TAB>REGEX`・`#`コメント可・**欠落/空=赤**（fail-closed 実測 exit 1）・ゲート自身は denylist ファイルをスキャンしない
- registry 依存検査は `--registry` 指定時のみ（不在時は明示 notice でスキップ）
- fixtures は中立名（example-org）・label-whitelist は外部ファイル化（excuse-only の非対称を README に明記）
- **handbook 自己適用**: T-6 ランナーの第5スイートに組込 → `make test` = `suites: declared=5 executed=5 skipped=0` 緑実測
- 移行手順（family-os / org の置換 = B9 レーン実施）は templates/publication-gate/README.md に併載

## 検証（実測）
- `--selftest` 全 pass / `make test` declared=5 緑 / denylist 欠落 → exit 1 + gate-error 行

## レビュー
公開前ゲート = リスク領域 → 5席（Opus 5 + GLM 5.3 + Grok 4.6 + Fable 5 + Codex sol-xhigh 同系統席）。writer = Codex Sol（純）

🤖 Generated with [Claude Code](https://claude.com/claude-code)