### PR TITLE
docs: CONTRIBUTING prerequisites + README Project status (#86, B8)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,6 +3,19 @@
 **このハンドブックは、自分自身のルールで更新される。** コントリビュートの手順そのものが、このリポが定めるプロトコル（L2/L1/L0）の実演になる。
 
 > **English summary**: This handbook is maintained under its own rules. To contribute: (1) file an Issue first with *Why / Done when / predicted files to touch*; (2) post a 4-field WIP declaration (`agent / date / Files to touch / Branch`) on the Issue before starting; (3) work in a dedicated worktree/branch, touching only declared files; (4) get a cross review — the merge-approving reviewer must be a different model or a different agent from the implementer (no self-approval); (5) put an L1-7 **completion record** (Done-when → PASS/FAIL/reasoned-N/A with inline evidence, candidate SHA, declared-vs-diff reconciliation, identity check) in the PR body. Field schemas: [templates/issue-template.md](templates/issue-template.md). Canonical docs are Japanese.
+> Prerequisites are Python 3.9+, `make`, and `git` on macOS or Linux; `make test` and `make lint` are the same entry points used by CI.
+
+## Prerequisites / 前提ツール
+
+ローカルでの変更と検証には、次の環境が必要です。macOS と Linux をサポートしています。
+
+| Requirement / 必要条件 | Notes / 補足 |
+|---|---|
+| Python 3.9+ | 呼び出されるチェッカーが Python 3.9+ を宣言し、`list[...]` などの組み込みジェネリック型構文（3.9+）を使います。必要なのは標準ライブラリのみで、`tomllib` やサードパーティ製パッケージは不要です。 |
+| `make` | `Makefile` の検証ターゲットを実行します。 |
+| `git` | 変更差分と worktree を管理します。 |
+
+テスト実行: `make test` と `make lint` は、CI が使うものと同じエントリーポイントです（T-1 / T-6）。
 
 ## 変更提案の流れ
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -394,6 +394,15 @@ docs と templates の機械翻訳版（English / 简体中文 / ไทย）は
 
 提案の入り口も、同じルールの上にあります。
 
+## Project status
+
+[![Test + Lint](https://github.com/caty-ai/family-dev-handbook/actions/workflows/test-lint.yml/badge.svg)](https://github.com/caty-ai/family-dev-handbook/actions/workflows/test-lint.yml)
+
+- CI: ローカル caller から Test + Lint を含む reusable `@ci-v1` セット（5ゲート）を実行し、suite-count 照合を有効にしています。CI と同じエントリーポイントをローカルで実行するには `make test` と `make lint` を使います。
+- 検証済み環境: CI で `ubuntu-latest` と `macos-latest` を実行し、macOS でのローカル開発も行っています。
+- maturity: `stable` — 規範の正本です。
+- 既知の制約: runtime code を持たない docs-only リポジトリです。また、タイ語ミラーの既知のリンク2件を [#89](https://github.com/caty-ai/family-dev-handbook/issues/89) で追跡しています。
+
 ---
 
 <a id="contributing"></a>

--- a/README.md
+++ b/README.md
@@ -397,6 +397,15 @@ What comes next is tracked canonically in the [Issue list](https://github.com/ca
 
 The way in for proposals sits on the same rules.
 
+## Project status
+
+[![Test + Lint](https://github.com/caty-ai/family-dev-handbook/actions/workflows/test-lint.yml/badge.svg)](https://github.com/caty-ai/family-dev-handbook/actions/workflows/test-lint.yml)
+
+- CI: Local callers exercise the reusable `@ci-v1` set (five gates), including Test + Lint; suite-count reconciliation is enabled. Run the same CI entry points locally with `make test` and `make lint`.
+- 検証済み環境: `ubuntu-latest` and `macos-latest` are exercised in CI; macOS is also used for local development.
+- maturity: `stable` — the normative canonical handbook.
+- 既知の制約: This is a docs-only repository with no runtime code; two known links in the Thai mirror are tracked in [#89](https://github.com/caty-ai/family-dev-handbook/issues/89).
+
 ---
 
 <a id="contributing"></a>

--- a/README.th.md
+++ b/README.th.md
@@ -397,6 +397,15 @@ flowchart TD
 
 ทางเข้าสำหรับข้อเสนอ ก็ตั้งอยู่บนกฎชุดเดียวกันนี้
 
+## Project status
+
+[![Test + Lint](https://github.com/caty-ai/family-dev-handbook/actions/workflows/test-lint.yml/badge.svg)](https://github.com/caty-ai/family-dev-handbook/actions/workflows/test-lint.yml)
+
+- CI: caller ในรีโปจะเรียกใช้ชุด reusable `@ci-v1` (ห้า gate) ซึ่งรวม Test + Lint และเปิดใช้การกระทบยอด suite-count แล้ว หากต้องการใช้ entry point เดียวกับ CI ในเครื่อง ให้รัน `make test` และ `make lint`
+- 検証済み環境: CI รันบน `ubuntu-latest` และ `macos-latest` รวมทั้งมีการพัฒนาในเครื่องบน macOS
+- maturity: `stable` — เป็นฉบับหลักเชิงบรรทัดฐาน
+- 既知の制約: เป็นรีโปเอกสารล้วนที่ไม่มี runtime code และลิงก์ที่ทราบปัญหาสองรายการในมิเรอร์ภาษาไทยกำลังติดตามอยู่ใน [#89](https://github.com/caty-ai/family-dev-handbook/issues/89)
+
 ---
 
 <a id="contributing"></a>

--- a/README.zh.md
+++ b/README.zh.md
@@ -397,6 +397,15 @@ Epic 车道（`E-1`–`E-10`）是可选的。只有在负责人批准之后才�
 
 提案的入口，也建立在同一套规则之上。
 
+## Project status
+
+[![Test + Lint](https://github.com/caty-ai/family-dev-handbook/actions/workflows/test-lint.yml/badge.svg)](https://github.com/caty-ai/family-dev-handbook/actions/workflows/test-lint.yml)
+
+- CI: 本地 caller 会运行包含 Test + Lint 在内的 reusable `@ci-v1` 套件（五个关卡），并已启用 suite-count 对账。若要在本地运行与 CI 相同的入口，请使用 `make test` 和 `make lint`。
+- 検証済み環境: CI 会运行 `ubuntu-latest` 与 `macos-latest`，本地开发也使用 macOS。
+- maturity: `stable` — 规范性正本。
+- 既知の制約: 这是一个不含运行时代码的纯文档仓库；泰语镜像中的两个已知链接由 [#89](https://github.com/caty-ai/family-dev-handbook/issues/89) 跟踪。
+
 ---
 
 <a id="contributing"></a>


### PR DESCRIPTION
Closes #86 (B8). Campaign tracking: https://github.com/caty-ai/family-os/issues/56

- CONTRIBUTING に Prerequisites 節（Python 3.9+ は `list[...]` 使用の実体根拠つき・stdlib のみ・make/git）+ `make test`/`make lint` 案内（CI と同一エントリポイント= T-1/T-6）
- README×4 に `## Project status` 節を **T-7 条文内蔵の標準形**で追加（live バッジ + CI/検証済み環境/maturity/既知の制約の4行・値はすべて実測ベース・#89 追跡込み）

🤖 Generated with [Claude Code](https://claude.com/claude-code)