### PR TITLE
reusable-gitleaks: allow path-less extend = { useDefault = true } only (#90, owner-ruled Option A)

### DIFF
--- a/.github/workflows/reusable-gitleaks.yml
+++ b/.github/workflows/reusable-gitleaks.yml
@@ -93,8 +93,9 @@ jobs:
           if [ -n "$BASE_CONFIG" ]; then
             git show "origin/${BASE_REF}:${BASE_CONFIG}" > /tmp/gitleaks-base-config.toml
             # [extend] の path は「設定ファイルの位置」ではなく実行時の作業ディレクトリ基準で解決される。
-            # base 設定が extend を持つと、参照先ファイルを PR 側 (checkout ツリー) が差し替えられ、
-            # base 固定を迂回できる — extend を含む base 設定は赤 (ルールは base 設定にインライン化する)。
+            # base 設定が extend.path を持つと、参照先ファイルを PR 側 (checkout ツリー) が差し替えられ、
+            # base 固定を迂回できる。path の無い useDefault = true のみは gitleaks 内蔵デフォルトを参照し、
+            # PR ツリーが差し替えられるファイルが無いため例外として許可する。それ以外の extend は赤。
             # 検出は文字列マッチではなく TOML の実パース ([ extend ]・["extend"]・inline table 等の
             # 別記法をすり抜けさせない)。パースできない設定も赤 (判定不能 = 赤・FP-6)。
             python3 -c '
@@ -105,8 +106,12 @@ jobs:
           except Exception as e:
               print(f"::error::base gitleaks config is not parseable TOML ({e}) — cannot judge, failing closed.")
               sys.exit(1)
-          if "extend" in data:
-              print("::error::base gitleaks config contains extend — extend paths resolve against the working directory and can be redirected to PR-controlled files. Inline all rules into the base config (fail-closed).")
+          if "extend" in data and not (
+              isinstance(data["extend"], dict)
+              and set(data["extend"]) == {"useDefault"}
+              and data["extend"]["useDefault"] is True
+          ):
+              print("::error::base gitleaks config contains a disallowed extend value — extend paths resolve against the working directory and can be redirected to PR-controlled files. Only extend = { useDefault = true } (equivalently, [extend] containing only useDefault = true) is allowed; all other extend forms fail closed.")
               sys.exit(1)
           ' || exit 1
             CONFIG_ARGS=(--config /tmp/gitleaks-base-config.toml)

--- a/.github/workflows/reusable-gitleaks.yml
+++ b/.github/workflows/reusable-gitleaks.yml
@@ -92,26 +92,29 @@ jobs:
           done
           if [ -n "$BASE_CONFIG" ]; then
             git show "origin/${BASE_REF}:${BASE_CONFIG}" > /tmp/gitleaks-base-config.toml
-            # [extend] の path は「設定ファイルの位置」ではなく実行時の作業ディレクトリ基準で解決される。
-            # base 設定が extend.path を持つと、参照先ファイルを PR 側 (checkout ツリー) が差し替えられ、
-            # base 固定を迂回できる。path の無い useDefault = true のみは gitleaks 内蔵デフォルトを参照し、
-            # PR ツリーが差し替えられるファイルが無いため例外として許可する。それ以外の extend は赤。
+            # extend は top-level key を大文字小文字を区別せず検出する。gitleaks は設定 key を再帰的に
+            # lowercase 化するため、case variant の extend.path も PR 側ファイルへの迂回になる。
+            # canonical lowercase の extend が一つだけあり、その中身が useDefault = true だけの場合に限り、
+            # PR ツリーが差し替えられるファイルを参照しないため許可する。それ以外の extend は赤。
             # 検出は文字列マッチではなく TOML の実パース ([ extend ]・["extend"]・inline table 等の
             # 別記法をすり抜けさせない)。パースできない設定も赤 (判定不能 = 赤・FP-6)。
             python3 -c '
-          import sys, tomllib
+          import sys
           try:
+              import tomllib
               with open("/tmp/gitleaks-base-config.toml", "rb") as f:
                   data = tomllib.load(f)
           except Exception as e:
               print(f"::error::base gitleaks config is not parseable TOML ({e}) — cannot judge, failing closed.")
               sys.exit(1)
-          if "extend" in data and not (
-              isinstance(data["extend"], dict)
+          ext_keys = [k for k in data if k.lower() == "extend"]
+          if ext_keys and not (
+              ext_keys == ["extend"]
+              and isinstance(data["extend"], dict)
               and set(data["extend"]) == {"useDefault"}
               and data["extend"]["useDefault"] is True
           ):
-              print("::error::base gitleaks config contains a disallowed extend value — extend paths resolve against the working directory and can be redirected to PR-controlled files. Only extend = { useDefault = true } (equivalently, [extend] containing only useDefault = true) is allowed; all other extend forms fail closed.")
+              print("::error::base gitleaks config contains a disallowed extend value — the top-level extend key is matched case-insensitively because gitleaks lowercases config keys. Only one canonical lowercase extend containing exactly useDefault = true is allowed; every case variant, sibling variant, and other extend form fails closed.")
               sys.exit(1)
           ' || exit 1
             CONFIG_ARGS=(--config /tmp/gitleaks-base-config.toml)

--- a/scripts/test-gitleaks-validator.py
+++ b/scripts/test-gitleaks-validator.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""Exercise the validator embedded in reusable-gitleaks.yml."""
+
+from pathlib import Path
+import subprocess
+import sys
+
+
+WORKFLOW = Path(".github/workflows/reusable-gitleaks.yml")
+CONFIG = Path("/tmp/gitleaks-base-config.toml")
+STEP_NAME = "Scan PR commit range"
+
+
+def indentation(line):
+    return len(line) - len(line.lstrip(" "))
+
+
+def extract_run_block(lines):
+    step_markers = []
+    for index, line in enumerate(lines):
+        if line.strip() == "- name: " + STEP_NAME:
+            step_markers.append((index, indentation(line)))
+    if len(step_markers) != 1:
+        raise ValueError(
+            "expected exactly one named workflow step, found "
+            + str(len(step_markers))
+        )
+
+    step_start, step_indent = step_markers[0]
+    run_markers = []
+    for index in range(step_start + 1, len(lines)):
+        line = lines[index]
+        if line.strip() and indentation(line) <= step_indent:
+            break
+        if line.strip() == "run: |":
+            run_markers.append((index, indentation(line)))
+    if len(run_markers) != 1:
+        raise ValueError(
+            "expected exactly one literal run block in named step, found "
+            + str(len(run_markers))
+        )
+
+    run_start, run_indent = run_markers[0]
+    raw_block = []
+    for line in lines[run_start + 1 :]:
+        if line.strip() and indentation(line) <= run_indent:
+            break
+        raw_block.append(line)
+    nonempty = [indentation(line) for line in raw_block if line.strip()]
+    if not nonempty:
+        raise ValueError("named workflow step has an empty run block")
+    content_indent = min(nonempty)
+    if content_indent <= run_indent:
+        raise ValueError("literal run block is not indented beneath run: |")
+    return [line[content_indent:] if line.strip() else "" for line in raw_block]
+
+
+def extract_validator(workflow):
+    run_lines = extract_run_block(workflow.read_text(encoding="utf-8").splitlines())
+    opening = [
+        index for index, line in enumerate(run_lines) if line.strip() == "python3 -c '"
+    ]
+    closing = [
+        index for index, line in enumerate(run_lines) if line.strip() == "' || exit 1"
+    ]
+    if len(opening) != 1 or len(closing) != 1 or closing[0] <= opening[0]:
+        raise ValueError(
+            "expected one complete single-quoted python3 -c validator payload"
+        )
+    validator = "\n".join(run_lines[opening[0] + 1 : closing[0]]) + "\n"
+    if not validator.strip():
+        raise ValueError("extracted validator payload is empty")
+    if "'" in validator:
+        raise ValueError("validator payload contains a single quote that breaks shell quoting")
+    return validator
+
+
+CASES = (
+    ("canonical-use-default", "[extend]\nuseDefault = true\n", True),
+    ("uppercase-path", '[EXTEND]\npath = "evil.toml"\n', False),
+    ("mixed-case-path", '[Extend]\npath = "evil.toml"\n', False),
+    ("mixed-case-use-default", "[Extend]\nuseDefault = true\n", False),
+    (
+        "canonical-then-sibling",
+        '[extend]\nuseDefault = true\n[Extend]\npath = "evil.toml"\n',
+        False,
+    ),
+    (
+        "sibling-then-canonical",
+        '[Extend]\npath = "evil.toml"\n[extend]\nuseDefault = true\n',
+        False,
+    ),
+    ("use-default-extra-key", '[extend]\nuseDefault = true\npath = "evil.toml"\n', False),
+    ("use-default-false", "[extend]\nuseDefault = false\n", False),
+    ("use-default-integer", "[extend]\nuseDefault = 1\n", False),
+    ("use-default-string", '[extend]\nuseDefault = "true"\n', False),
+    ("array-of-tables", "[[extend]]\nuseDefault = true\n", False),
+    ("dotted-use-default", "extend.useDefault = true\n", True),
+    (
+        "duplicate-key-parse-error",
+        "[extend]\nuseDefault = true\nuseDefault = false\n",
+        False,
+    ),
+    ("non-extend-config", '[rules]\nid = "example"\n', True),
+)
+
+
+def main():
+    try:
+        validator = extract_validator(WORKFLOW)
+    except (OSError, UnicodeError, ValueError) as error:
+        print("FAIL validator-extraction: " + str(error))
+        return 1
+
+    if CONFIG.exists():
+        print("FAIL fixture-path-occupied: " + str(CONFIG))
+        return 1
+
+    failures = 0
+    try:
+        for name, fixture, should_allow in CASES:
+            CONFIG.write_text(fixture, encoding="utf-8")
+            result = subprocess.run(
+                [sys.executable, "-B", "-c", validator],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            allowed = result.returncode == 0
+            error_line = result.stdout.strip()
+            valid_denial = allowed or (
+                result.returncode == 1 and error_line.startswith("::error::")
+            )
+            if allowed == should_allow and valid_denial:
+                print("PASS " + name + " (" + ("allow" if allowed else "deny") + ")")
+            else:
+                failures += 1
+                expected = "allow" if should_allow else "deny"
+                actual = "allow" if allowed else "deny"
+                print(
+                    "FAIL "
+                    + name
+                    + " (expected="
+                    + expected
+                    + " actual="
+                    + actual
+                    + " exit="
+                    + str(result.returncode)
+                    + ")"
+                )
+                if result.stdout:
+                    print(result.stdout.rstrip())
+                if result.stderr:
+                    print(result.stderr.rstrip())
+    finally:
+        if CONFIG.exists():
+            CONFIG.unlink()
+
+    print("summary fixtures=" + str(len(CASES)) + " failures=" + str(failures))
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -46,6 +46,7 @@ register_suite # The four localized READMEs have matching structure.
 register_suite # Seat-resolver unit tests.
 register_suite # Seat-resolver conformance vectors.
 register_suite # Publication-gate self-test.
+register_suite # Reusable-gitleaks embedded-validator regression matrix.
 
 if [ "$#" -ne 0 ]; then
     printf 'FAIL usage (expected=no-arguments)\n' >&2
@@ -111,6 +112,7 @@ run_suite readme-structure "$python_bin" -B scripts/readme-check/inspect_readme.
 run_suite seat-resolver-unit "$python_bin" -B -m unittest discover -s templates/seat-resolver/tests -v
 run_suite seat-resolver-conformance run_conformance
 run_suite publication-gate-template "$python_bin" -B templates/publication-gate/check_publication_gate.py --selftest
+run_suite gitleaks-validator "$python_bin" -B scripts/test-gitleaks-validator.py
 
 if [ "$failures" -ne 0 ]; then
     exit 1


### PR DESCRIPTION
## Why

Closes the first-adopter deadlock recorded in #90: the blanket `extend` ban in `reusable-gitleaks.yml` also rejected the safe path-less form, blocking family-memory-architecture#28 / PR#41. Owner ruling (recorded on #90, 2026-08-20): **Option A — narrow the ban**. Frozen semantics: allow `extend` **iff** the parsed TOML value is a table containing exactly one key `useDefault` with boolean `true`. Everything else — `extend.path` (with or without `useDefault`), extra keys, non-boolean values, non-table shapes, unparseable TOML — stays fail-closed exactly as before.

## Files (L0-6)

- `.github/workflows/reusable-gitleaks.yml` — 9+/4-: exact-structural-match allow branch on the parsed TOML; comment block and error message updated to state the one allowed form. Declared on #90 WIP; `scripts/test.sh` was declared conditionally and intentionally not touched (the rig does not execute workflow-embedded Python — dynamic evidence comes from the fixture matrix below and the GHA dry-run phase).

## Evidence (writer = codex GPT-5.6 Sol, lane record on #90)

Fixture matrix (python3 -B, actual output): `allow-useDefault-only: ALLOW` / `deny-path: DENY` / `deny-useDefault-plus-extra: DENY` / `deny-useDefault-false: DENY` / `deny-useDefault-string: DENY` / `deny-array-of-tables: DENY` — 6/6. `make test` (5/5 suites) and `make lint` pass; YAML parse verified.

## Merge-blocking checklist (do not merge until all checked)

- [x] GHA dry-run on a throwaway branch: deny fixtures red, allow fixture green (harness#65 pattern)
- [x] Enforcement 5-seat panel GO (writer=Codex Sol → panel: Opus 5 + GLM 5.3 + Grok 4.6 + Fable 5 + Codex sol-xhigh as recorded same-family seat)
- [ ] Owner tag decision (ci-v1 retag / new tag per templates/ci versioning policy)
- [ ] Downstream first-green: FMA #28 / PR#41 fresh run after retag (adoption evidence)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

