### PR TITLE
reusable-release-sync: Release title from the tag message's first line, with a pinned locale (#114)

### DIFF
--- a/.github/workflows/reusable-release-sync.yml
+++ b/.github/workflows/reusable-release-sync.yml
@@ -30,6 +30,10 @@ jobs:
     env:
       GH_TOKEN: ${{ github.token }}
       GH_REPO: ${{ github.repository }}
+      # `${#TITLE}` を文字数として数え、[[:space:]] が全角空白 (U+3000) を分類するよう、
+      # title logic を runner の locale によらず決定論にする。全 LC_* と LANG に優先し、
+      # runner 側の export で上書きされない LC_ALL を pin する。
+      LC_ALL: C.UTF-8
     steps:
       - name: Require a pushed tag
         env:
@@ -198,7 +202,19 @@ jobs:
         if: env.RELEASE_SYNC_EXEMPT != 'true' && env.CREATE_RELEASE == 'true'
         run: |
           set -euo pipefail
-          CREATE_ARGS=("$TAG" --verify-tag --title "$TAG" --notes-file -)
+          IFS= read -r TITLE < "$TAG_MESSAGE_FILE" || true
+          TITLE=${TITLE%$'\r'}
+          TITLE=$(printf '%s' "$TITLE" | sed 's/^[[:space:]]*//; s/[[:space:]]*$//')
+          if [ -z "$TITLE" ]; then
+            echo "::warning::Release title falls back to tag name $TAG because the first tag-message line is empty after trimming."
+            TITLE="$TAG"
+          # Git subject は約50〜72文字。120超はsubjectなしで本文を書いたものとみなし、
+          # 切り詰めで内容を黙って偽るよりTAGへ戻して、API側の長さ制限も避ける。
+          elif [ "${#TITLE}" -gt 120 ]; then
+            echo "::warning::Release title falls back to tag name $TAG because the first tag-message line exceeds 120 characters."
+            TITLE="$TAG"
+          fi
+          CREATE_ARGS=("$TAG" --verify-tag --title "$TITLE" --notes-file -)
           if [ "$IS_PRERELEASE" = "true" ]; then
             CREATE_ARGS+=(--prerelease)
           fi


### PR DESCRIPTION
Implements #114 section A. This PR leaves #114 open — section B (backfilling 19 existing releases) happens after this merges, and the completion record lands on the issue.

## What

`--title "$TAG"` (hardcoded tag name) → title derived from the tag message's first line:

- trailing CR stripped, leading/trailing whitespace trimmed
- empty/whitespace-only first line → falls back to `$TAG` with an explicit `::warning::`
- first line > 120 characters → falls back to `$TAG` with an explicit `::warning::` (fallback rather than truncation: truncating would silently misrepresent the content; 120 is far below GitHub's 255-char Release-name ceiling)
- notes unchanged — the full tag message is still piped to `--notes-file -`
- **`LC_ALL: C.UTF-8` pinned at job level** (delta after round-1 review, see below)

Measured impact this fixes: 19 of 59 published releases across the 11 public family repos currently show only a version number, while the tag message's first line — the human-facing title the author actually wrote — sits buried in the notes. See the table on #114.

## Review — S 3 seats, round 1 → delta → cumulative

Round 1 (pre-locale-pin): **GLM 5.3 GO (with a pre-merge flip recommendation) / Kimi K3 NO-GO / Grok 4.6 NO-GO** — three independent seats converged on one MAJOR: with no locale pinned, `${#TITLE}` counts **bytes** under `LC_ALL=C`/POSIX, so a legitimate Japanese first line of ~41 characters (123 bytes) falls back to the bare tag name — reintroducing the exact symptom this issue removes. A fullwidth-space-only first line likewise survives trimming as a blank-looking title.

Evidence quality: Grok reproduced it on Docker `ubuntu:24.04` (glibc, GNU sed 4.9, bash 5.2.21 — runner-equivalent), Kimi and GLM independently on macOS across four locales. GLM additionally established that today's GitHub-hosted default (`LANG=C.UTF-8`, `LC_ALL` unset) makes it latent rather than live, and that `workflow_call` declares no inputs so a caller cannot inject a locale — the pin belongs in this file.

Delta `7eaf763`: one job-level `env:` entry, matching the sibling precedent `reusable-review-labels.yml:86-91` (same pin, same reason, `LC_ALL` over `LANG` because it cannot be overridden by a runner-side export). Adjudication and the explicitly-declined findings (NBSP MINOR, `--title=` equals form, mid-line bare CR) are recorded on #114.

Post-delta verification (writer, under the inherited pin): Japanese 41 chars/123 bytes → title **kept**; 50 chars/150 bytes → kept; U+3000 ×3 → warning + fallback; ASCII 120 → kept; 121 → warning + fallback. `actionlint` exit 0.

Seat delta ballots are being collected and will be posted here before merge.

## Untrusted input

The tag message is human free text. All three seats proved by execution — with a `gh` stub printing argv, and Grok additionally against real `gh` 2.86.0 (API payload showed `"name": "--draft"`, `"draft": false`) — that a first line like `--draft`, `-n`, `$(id)`, backticks, or embedded quotes reaches `gh` as one literal title argument: never a flag, never evaluated by the shell.

## Unchanged fail-closed contracts

annotated-tag requirement, v-prefixed SemVer, empty-tag-message rejection, exemption path, existing-Release/draft detection, prerelease flag, and the concurrent-creation re-check — all verified byte-identical by three seats.

## Dogfood

The tag cut when this merges is itself produced by the new wiring; its title (not equal to the tag name) plus the run URL go into the completion record on #114.

🤖 Generated with [Claude Code](https://claude.com/claude-code)