### PR TITLE
templates/ci: required 登録が守る範囲と素通り経路の明文化（FP-5）(#125)

### DIFF
--- a/templates/ci/README.md
+++ b/templates/ci/README.md
@@ -42,6 +42,10 @@
    ```
    登録確認を README のお願いで終わらせない（R-6 の自己適用）。branch protection が張れない環境（private の無償プラン等）は、その旨を導入台帳に明示記録する（FP-5: 劣化の可視化）。あわせて **detect-risk-paths ジョブのログに死にパターンの `::warning::` が出ていないことを確認する**（警告は「緑だが守れていない可能性」の唯一のシグナル — 出ていたら宣言を直してから「展開済み」）
 
+### required 登録が守る範囲 — オーナーの merge 経路は素通りする（FP-5）
+
+required 登録は「機械が merge を止める鍵」を意味しない。branch protection が機械的に効くのは **(i) 非 admin の PR merge (ii) force-push / branch 削除**のみ。家族の既定運用（`enforce_admins: false` + `gh pr merge` 禁止 → オーナー名義のローカル merge + push — [docs/03](../../docs/03-git-protocol.md)）では、**オーナーの merge 経路で required checks は一度も評価されない＝素通りする**（実測 2026-08-21/23: 家族9リポすべて `enforce_admins: false`・FMA 一貫性キャンペーンの merge 10本は全てこの経路で main に入った）。この経路を守るのは登録ではなく運用規律である — **merge 前に PR 画面で required の全チェックが緑であることを確認し、push は単独コマンドで実行して出力を確認する**（`&&` チェーンや pipeline に混ぜると push の失敗を飲む）。したがって「required に登録済み」を「守られている」と申告・誤読しないこと。登録が買うのは、非 admin 経路の機械強制と、オーナー経路が merge 前に照合する**チェックリストの正本**であって、鍵ではない（FP-5: fail-open は「チェックが通った」を意味しない）。
+
 ## バージョニング
 
 `@ci-v1` は handbook のリリースで維持する **moving major タグ**（`actions/checkout@v6` と同じ慣行 —

--- a/templates/ci/README.md
+++ b/templates/ci/README.md
@@ -44,7 +44,7 @@
 
 ### required 登録が守る範囲 — オーナーの merge 経路は素通りする（FP-5）
 
-required 登録は「機械が merge を止める鍵」を意味しない。branch protection が機械的に効くのは **(i) 非 admin の PR merge (ii) force-push / branch 削除**のみ。家族の既定運用（`enforce_admins: false` + `gh pr merge` 禁止 → オーナー名義のローカル merge + push — [docs/03](../../docs/03-git-protocol.md)）では、**オーナーの merge 経路で required checks は一度も評価されない＝素通りする**（実測 2026-08-21/23: 家族9リポすべて `enforce_admins: false`・FMA 一貫性キャンペーンの merge 10本は全てこの経路で main に入った）。この経路を守るのは登録ではなく運用規律である — **merge 前に PR 画面で required の全チェックが緑であることを確認し、push は単独コマンドで実行して出力を確認する**（`&&` チェーンや pipeline に混ぜると push の失敗を飲む）。したがって「required に登録済み」を「守られている」と申告・誤読しないこと。登録が買うのは、非 admin 経路の機械強制と、オーナー経路が merge 前に照合する**チェックリストの正本**であって、鍵ではない（FP-5: fail-open は「チェックが通った」を意味しない）。
+required 登録は「機械が merge を止める鍵」を意味しない。家族の現構成（required status checks + 既定設定・`enforce_admins: false`）で branch protection が機械的に止めるのは **(i) 非 admin による protected branch の更新（PR merge・required 未通過 commit の直接 push とも） (ii) force-push / branch 削除（こちらは admin にも効く）**。admin は (i) を素通りできるため、家族の既定運用 — PR を GitHub API/UI で merge せず、オーナー名義でローカル merge + push する（成文は [publication-checklist D3](../publication-checklist.md) のローカル `--no-ff` merge。[docs/03](../../docs/03-git-protocol.md) L0-7 のローカル merge 手順と整合するが、API/UI merge 不使用そのものの L0 明文は現在ない）— では、**オーナーの merge 経路で required checks はゲートとして一度も評価されない＝素通りする**（実測 2026-08-21/23・記録は [#125](https://github.com/caty-ai/family-dev-handbook/issues/125): 家族9リポすべて `enforce_admins: false`・FMA 一貫性キャンペーンの merge 10本は全てこの経路で main に入った）。この経路を守るのは登録ではなく運用規律である — **merge 前に PR 画面で required の全チェックが緑であることを確認し、push は単独コマンドで実行して出力を確認する**（`&&` チェーンや pipeline に混ぜると push の失敗・出力を見ずに先へ進む）。したがって「required に登録済み」を「守られている」と申告・誤読しないこと。登録が買うのは、非 admin 経路の機械強制と、オーナー経路が merge 前に照合する **required 登録済み check 名の一覧**（`check-required-checks.sh` の `EXPECTED` が機械照合する対象）であって、鍵ではない（FP-5: fail-open は「チェックが通った」を意味しない）。
 
 ## バージョニング
 
@@ -111,7 +111,7 @@ hardening として強く推奨する。
 
 ## 落とし穴
 
-- **required checks 未登録** — 門番は赤を出すが merge は止まらない。手順 6 の機械確認まで終えて「展開済み」
+- **required checks 未登録** — 門番は赤を出すが merge は止まらない。手順 6 の機械確認まで終えて「展開済み」。なお登録してもオーナーの merge 経路は止まらない（手順 6 直後の「required 登録が守る範囲」節）
 - **展開検証のダミー secret に bare な AWS access key ID（AKIA+16桁）を使わない** — gitleaks v8.30.1 の既定ルールでは access key ID 単体は検知されず、「門番が壊れている」ように見える偽陰性になる。検知確認済みフィクスチャ（例: 切り詰めた PEM 秘密鍵ブロック）を使う。仕込みはサーバーサイドコミット（contents API）推奨 — ローカルの secret 検知フックと手元 commit がデッドロックするため
 - **test/lint の充て先は「対象0件で緑」にならない形に** — 対象を数えて0件なら赤にする（導入例: 本リポ自身の Makefile は対象ファイルの非空ガード込み）。`with:` でコマンドを差し替えられるわけではない（reusable 側は Makefile の `test`/`lint` ターゲット固定）ので、この性質は reusable 側で保たれる
 - **シェルスクリプトの lint 充て先は `*.sh` glob だけにしない** — 拡張子なし（shebang のみ）のスクリプトが漏れる。shebang スキャン（例: `grep -rl '^#!.*sh' --exclude-dir=.git`）を併用して対象を組み立てる


### PR DESCRIPTION
Closes #125

## 何を変えるか

`templates/ci/README.md` の展開手順 step 6 直後に、required checks 登録の効力範囲を正直に書く1段落（見出し `### required 登録が守る範囲 — オーナーの merge 経路は素通りする（FP-5）`）を追加する。あわせて落とし穴の先頭項目に新節への相互参照1行。

- 機械的に止まる範囲: 非 admin の protected branch 更新（PR merge・required 未通過 commit の直接 push）/ force-push・branch 削除（admin にも効く）
- 効かない経路: `enforce_admins: false` + オーナー名義のローカル merge + push（家族9リポ実測・FMA merge 10本の実証つき・記録= #125）
- その経路を守る規律: merge 前に PR の required 全緑確認 → push 単独実行で出力確認

語彙・ラベル・台帳様式は新設しない（#78 のスコープと非交差）。

## 完了記録 (Completion record)

candidate SHA: 87eb47072a8b60851b136f14bc0dbf7b8ccdb9ab
implementer: Alpha（Claude Fable 5 / claude-fable-5・session 253e314d）— md docs のため直接編集（code_workflow の非コード枠）
reviewer: 異種3席ブラインド + delta。GLM 5.3（requested=glm-5.3 / actual=glm-5.3・CLI -p・隔離 cwd・read-only）= GO-WITH-COMMENTS（MINOR4）/ Kimi K3（requested=kimi-k3 / actual=kimi-k3・CLI -p）= GO-WITH-COMMENTS（MINOR4）/ Grok 4.6（requested=grok-4.6 / actual=grok-4.6・--prompt-file）= 初回 GO-WITH-COMMENTS（MAJOR2+MINOR1）→ 87eb470 への delta で **累積 GO**（「Findings 1–3 resolved / No new problems / Merge 87eb470」）。席選定= loom-seats --size S（selection_fn_version 7・2026-08-23）・correlated-seats なし
identity check: 別モデル（writer=Anthropic / 席=Zhipu・Moonshot・xAI — 相互異種）
CI: green — 87eb470 の statusCheckRollup 実測（2026-08-23）: test-lint / test=SUCCESS・test-lint / lint=SUCCESS・test-lint / test-macos=SUCCESS・gitleaks / gitleaks=SUCCESS・history-check / history-check=SUCCESS・risk-review-gate / risk-review-gate=SUCCESS・pr-size / pr-size=SUCCESS（test-macos-skip=SKIPPED は対仕様どおり）。本文 prose は Makefile:5 により機械検査対象外（既知・#78 レビュー C7 と同一事項）
release: v0.20.1（規範の明確化＝出荷相当。条文 rule の追加はないため patch）
previous release: v0.20.0 → https://github.com/caty-ai/family-dev-handbook/releases/tag/v0.20.0（gh release view で実在確認 2026-08-23・published=2026-08-21T06:02:46Z・履行済み）

### Done when → 結果

| Done when 項目 | 結果 | 証拠（コマンド or 手順 + 観測結果 + 日付） |
|---|---|---|
| 段落が①効く範囲②効かない経路③守る規律の3点を含む | PASS | templates/ci/README.md（87eb470）の新節に「(i) 非 admin による protected branch の更新…(ii) force-push / branch 削除」「オーナーの merge 経路で required checks はゲートとして一度も評価されない」「merge 前に PR 画面で required の全チェックが緑であることを確認し、push は単独コマンドで実行して出力を確認する」を確認（2026-08-23）。3席の Done-when 対照でも 3/3 PASS |
| 語彙・ラベル・台帳様式を新設していない（#78 非交差） | PASS | 3席全席+delta が独立確認（Grok delta: "No #78 vocab. No 正本 collision"・GLM: 「Issue #78（語彙・台帳の差し戻しレーン）と非交差」）（2026-08-23） |
| CI green | PASS | 上記 CI 欄の statusCheckRollup 実測どおり全 SUCCESS（2026-08-23） |
| release 欄の宣言と履行 | PASS | 本記録で v0.20.1 を宣言。merge 後に annotated tag + GitHub Release を切り、MERGED コメントに URL を記載して履行（T-5） |

### 宣言 vs 実 diff（L0-6）

git diff --stat origin/main...87eb470: `templates/ci/README.md | 8 ++++++--`（1 file changed）
宣言ファイル集合との差分: なし（WIP 宣言= templates/ci/README.md のみ・一致）

### レビュー経緯（L1-8 相当の可視化）

初回レビュー対象= 8599ad4。3席の収束指摘（docs/03 引用の緩さ / (i) の狭さ / 「チェックリストの正本」の語衝突 / 実測出典なし）を 87eb470 で全採用し、MAJOR を出した Grok 席の delta で累積 GO を得た。GLM F4（落とし穴への相互参照・任意）も採用。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
