### PR TITLE
docs: name WSL2 as a supported environment (CONTRIBUTING + verified-environments, 4 langs)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,11 +3,11 @@
 **このハンドブックは、自分自身のルールで更新される。** コントリビュートの手順そのものが、このリポが定めるプロトコル（L2/L1/L0）の実演になる。
 
 > **English summary**: This handbook is maintained under its own rules. To contribute: (1) file an Issue first with *Why / Done when / predicted files to touch*; (2) post a 4-field WIP declaration (`agent / date / Files to touch / Branch`) on the Issue before starting; (3) work in a dedicated worktree/branch, touching only declared files; (4) get a cross review — the merge-approving reviewer must be a different model or a different agent from the implementer (no self-approval); (5) put an L1-7 **completion record** (Done-when → PASS/FAIL/reasoned-N/A with inline evidence, candidate SHA, declared-vs-diff reconciliation, identity check) in the PR body. Field schemas: [templates/issue-template.md](templates/issue-template.md). Canonical docs are Japanese.
-> Prerequisites are Python 3.9+, `make`, and `git` on macOS or Linux; `make test` and `make lint` are the same entry points used by CI.
+> Prerequisites are Python 3.9+, `make`, and `git` on macOS or Linux — WSL2 included (clone inside the Linux filesystem, not `/mnt/c`); `make test` and `make lint` are the same entry points used by CI.
 
 ## Prerequisites / 前提ツール
 
-ローカルでの変更と検証には、次の環境が必要です。macOS と Linux をサポートしています。
+ローカルでの変更と検証には、次の環境が必要です。macOS と Linux（WSL2 を含む）をサポートしています。WSL2 では `/mnt/c` 配下ではなく Linux ファイルシステム側に clone してください（git の速度低下と CRLF の混入を避けるため）。
 
 | Requirement / 必要条件 | Notes / 補足 |
 |---|---|

--- a/README.ja.md
+++ b/README.ja.md
@@ -412,7 +412,7 @@ docs と templates の機械翻訳版（English / 简体中文 / ไทย）は
 [![Test + Lint](https://github.com/caty-ai/family-dev-handbook/actions/workflows/test-lint.yml/badge.svg)](https://github.com/caty-ai/family-dev-handbook/actions/workflows/test-lint.yml)
 
 - CI: ローカル caller から Test + Lint を含む reusable `@ci-v1` セット（5ゲート）を実行し、suite-count 照合を有効にしています。CI と同じエントリーポイントをローカルで実行するには `make test` と `make lint` を使います。
-- 検証済み環境: CI で `ubuntu-latest` と `macos-latest` を実行し、macOS でのローカル開発も行っています。
+- 検証済み環境: CI で `ubuntu-latest` と `macos-latest` を実行し、macOS でのローカル開発も行っています。WSL2 も対象です — `ubuntu-latest` レーンが検証しているのと同じ GNU 経路で動きます（clone は `/mnt/c` 配下ではなく Linux ファイルシステム側に）。
 - maturity: `stable` — 規範の正本です。
 - 既知の制約: runtime code を持たない docs-only リポジトリです。また、タイ語ミラーの既知のリンク2件を [#89](https://github.com/caty-ai/family-dev-handbook/issues/89) で追跡しています。
 

--- a/README.md
+++ b/README.md
@@ -415,7 +415,7 @@ The way in for proposals sits on the same rules.
 [![Test + Lint](https://github.com/caty-ai/family-dev-handbook/actions/workflows/test-lint.yml/badge.svg)](https://github.com/caty-ai/family-dev-handbook/actions/workflows/test-lint.yml)
 
 - CI: Local callers exercise the reusable `@ci-v1` set (five gates), including Test + Lint; suite-count reconciliation is enabled. Run the same CI entry points locally with `make test` and `make lint`.
-- 検証済み環境: `ubuntu-latest` and `macos-latest` are exercised in CI; macOS is also used for local development.
+- 検証済み環境: `ubuntu-latest` and `macos-latest` are exercised in CI; macOS is also used for local development. WSL2 is in scope as well — it runs the same GNU path the `ubuntu-latest` lane verifies (clone inside the Linux filesystem, not `/mnt/c`).
 - maturity: `stable` — the normative canonical handbook.
 - 既知の制約: This is a docs-only repository with no runtime code; two known links in the Thai mirror are tracked in [#89](https://github.com/caty-ai/family-dev-handbook/issues/89).
 

--- a/README.th.md
+++ b/README.th.md
@@ -415,7 +415,7 @@ flowchart TD
 [![Test + Lint](https://github.com/caty-ai/family-dev-handbook/actions/workflows/test-lint.yml/badge.svg)](https://github.com/caty-ai/family-dev-handbook/actions/workflows/test-lint.yml)
 
 - CI: caller ในรีโปจะเรียกใช้ชุด reusable `@ci-v1` (ห้า gate) ซึ่งรวม Test + Lint และเปิดใช้การกระทบยอด suite-count แล้ว หากต้องการใช้ entry point เดียวกับ CI ในเครื่อง ให้รัน `make test` และ `make lint`
-- 検証済み環境: CI รันบน `ubuntu-latest` และ `macos-latest` รวมทั้งมีการพัฒนาในเครื่องบน macOS
+- 検証済み環境: CI รันบน `ubuntu-latest` และ `macos-latest` รวมทั้งมีการพัฒนาในเครื่องบน macOS นอกจากนี้ WSL2 ก็อยู่ในขอบเขตการรองรับด้วย — ใช้เส้นทาง GNU เดียวกับที่เลน `ubuntu-latest` ตรวจสอบไว้ (ให้ clone ลงในไฟล์ซิสเต็มฝั่ง Linux ไม่ใช่ใต้ `/mnt/c`)
 - maturity: `stable` — เป็นฉบับหลักเชิงบรรทัดฐาน
 - 既知の制約: เป็นรีโปเอกสารล้วนที่ไม่มี runtime code และลิงก์ที่ทราบปัญหาสองรายการในมิเรอร์ภาษาไทยกำลังติดตามอยู่ใน [#89](https://github.com/caty-ai/family-dev-handbook/issues/89)
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -415,7 +415,7 @@ Epic 车道（`E-1`–`E-10`）是可选的。只有在负责人批准之后才�
 [![Test + Lint](https://github.com/caty-ai/family-dev-handbook/actions/workflows/test-lint.yml/badge.svg)](https://github.com/caty-ai/family-dev-handbook/actions/workflows/test-lint.yml)
 
 - CI: 本地 caller 会运行包含 Test + Lint 在内的 reusable `@ci-v1` 套件（五个关卡），并已启用 suite-count 对账。若要在本地运行与 CI 相同的入口，请使用 `make test` 和 `make lint`。
-- 検証済み環境: CI 会运行 `ubuntu-latest` 与 `macos-latest`，本地开发也使用 macOS。
+- 検証済み環境: CI 会运行 `ubuntu-latest` 与 `macos-latest`，本地开发也使用 macOS。WSL2 同样在支持范围内 — 它运行的正是 `ubuntu-latest` 通道所验证的同一条 GNU 路径（请把仓库 clone 到 Linux 文件系统内，而不是 `/mnt/c` 下）。
 - maturity: `stable` — 规范性正本。
 - 既知の制約: 这是一个不含运行时代码的纯文档仓库；泰语镜像中的两个已知链接由 [#89](https://github.com/caty-ai/family-dev-handbook/issues/89) 跟踪。
 

--- a/templates/ci/README.md
+++ b/templates/ci/README.md
@@ -23,7 +23,7 @@
 ## 展開手順（コピペ順）
 
 1. `templates/ci/*.yml`（**caller stencil**）を対象リポの `.github/workflows/` へ、`scripts/assemble_review_comment.py` を `scripts/ci/` へコピー（Layer 2 を使わないなら合成器は後回しでよく、`release-sync.yml` は下記 release-sync 節の導入順（handbook release + `ci-v1` 前進の確認）を満たすまでコピーしない）。各ファイルの `uses:` 行が `caty-ai/family-dev-handbook/.github/workflows/reusable-<gate>.yml@ci-v1` を pin していることを確認する（バージョニングは下記「バージョニング」節を参照）
-   - コスト注: `test-lint.yml` は既定で `macos-latest` レグを含む（GitHub ホステッドランナーの分課金は Linux の10倍・`reusable-test-lint.yml:128`）。macOS 検証が不要な採用先（WSL2 / Linux のみの環境など）は、手順4の `run_macos: false` + `macos_skip_reason` で明示的に落とせる
+   - コスト注: `test-lint.yml` は既定で `macos-latest` レグを含む（private リポでは GitHub ホステッドランナーの分課金が Linux の10倍 — 根拠= `reusable-test-lint.yml:17` の header 注記と `:128` の macOS レグ）。macOS 検証が不要な採用先（WSL2 / Linux のみの環境など）は、手順4の `run_macos: false` + `macos_skip_reason` で明示的に落とせる
 2. `.github/risk-reviewers.txt` を作成: `risk-reviewers.txt.example` をコピーし、オーナー（人間）の GitHub ID を記入（プレースホルダのままなら赤）
 3. ラベルを作成:
    ```bash

--- a/templates/ci/README.md
+++ b/templates/ci/README.md
@@ -23,6 +23,7 @@
 ## 展開手順（コピペ順）
 
 1. `templates/ci/*.yml`（**caller stencil**）を対象リポの `.github/workflows/` へ、`scripts/assemble_review_comment.py` を `scripts/ci/` へコピー（Layer 2 を使わないなら合成器は後回しでよく、`release-sync.yml` は下記 release-sync 節の導入順（handbook release + `ci-v1` 前進の確認）を満たすまでコピーしない）。各ファイルの `uses:` 行が `caty-ai/family-dev-handbook/.github/workflows/reusable-<gate>.yml@ci-v1` を pin していることを確認する（バージョニングは下記「バージョニング」節を参照）
+   - コスト注: `test-lint.yml` は既定で `macos-latest` レグを含む（GitHub ホステッドランナーの分課金は Linux の10倍・`reusable-test-lint.yml:128`）。macOS 検証が不要な採用先（WSL2 / Linux のみの環境など）は、手順4の `run_macos: false` + `macos_skip_reason` で明示的に落とせる
 2. `.github/risk-reviewers.txt` を作成: `risk-reviewers.txt.example` をコピーし、オーナー（人間）の GitHub ID を記入（プレースホルダのままなら赤）
 3. ラベルを作成:
    ```bash


### PR DESCRIPTION
Closes #130 (parent: family-os#139). Size S, docs only — environment wording only, no normative rule text touched.

## What

- **CONTRIBUTING.md** — EN summary (line 6) and JA Prerequisites (line 10) now name WSL2 as in-scope, each carrying the one-line "clone inside the Linux filesystem, not `/mnt/c`" note.
- **README.md / README.ja.md / README.zh.md / README.th.md** — the verified-environments sentence in Project status now mentions WSL2 with covered-by-ubuntu wording (same GNU path the `ubuntu-latest` lane verifies), 4-language parity.
- **templates/ci/README.md** — deployment step 1 gains a cost note: on private repos the `macos-latest` leg bills at 10x Linux minutes (rationale: `reusable-test-lint.yml:17` header note; the leg itself: `:128`); adopters without macOS needs (WSL2 / Linux only) can drop it via the documented `run_macos: false` + `macos_skip_reason` inputs. (Private-repo qualifier + citation precision adopted from the converged review MINOR, delta commit `1971913`.)

## Files touched (= WIP declaration, no delta)

- CONTRIBUTING.md
- README.md
- README.ja.md
- README.zh.md
- README.th.md
- templates/ci/README.md

## 完了記録 (L1-7) — 差し替え記録 (L1-8)

> **L1-8 superseding note (2026-08-27)**: レビュー時の候補 SHA `1971913` の後に main が前進（#131 RS-8 label merge・`7b4ff1d`・触るファイル非交差）したため、L0-7 に従い rebase → 再検証した。**内容不変の証明** = `git range-diff eb46998..1971913 origin/main..HEAD` で両コミットとも `=`（beacb66→178cfd2 / 1971913→dc2e210）。rebase 後の再検証: `make test` exit 0（suites: declared=6 executed=6 skipped=0）+ `make lint` exit 0（2026-08-27 実測）。席レビューの findings は SHA 束縛のまま有効（diff 内容が byte 同一のため）。以下の記録は候補 SHA を差し替えた完全版。

**候補 SHA**: `dc2e2107c9bd75e37e67e46788c5fad2d6b3617f` (= PR head, rebase 後 push を実測)

### Done when → 判定

| Done when | 判定 | 証拠（インライン・2026-08-27 観測） |
|---|---|---|
| CONTRIBUTING names WSL2 + one-line "clone inside the Linux filesystem, not /mnt/c" note | **PASS** | CONTRIBUTING.md:6 "on macOS or Linux — WSL2 included (clone inside the Linux filesystem, not `/mnt/c`)" / :10 「macOS と Linux（WSL2 を含む）をサポートしています。WSL2 では `/mnt/c` 配下ではなく Linux ファイルシステム側に clone してください…」。3席が実ファイルで確認 |
| README verified-environments mentions WSL2 (covered-by-ubuntu wording), 4-language parity | **PASS** | README.md:418 / README.ja.md:415 / README.zh.md:418 / README.th.md:418 — 4言語とも「WSL2 も対象・`ubuntu-latest` レーンが検証する同一 GNU 経路・clone は Linux FS 側」の同一主張。全3席が sentence-by-sentence でパリティ確認（「WSL2 が CI 実行対象」との主張はどの言語にも無いことを明示確認）。make test の README 構造パリティゲートも PASS |
| (Optional) template intro notes the macOS-leg opt-out | **PASS** | templates/ci/README.md:26（展開手順 step 1 直下 = stencil をコピーする場所・step 4 の入力文書 :34-35 へ誘導）。GLM 席: 「intro より適所」と INFO 評価 |
| `make test` green (docs-only) | **PASS** | worktree で実行 `suites: declared=6 executed=6 skipped=0` exit 0（writer 2026-08-27 実測・delta 後 1971913 で再実行 exit 0。Kimi/GLM/Grok 3席も各自 `make test` を独立実行し green を確認）。`make lint` も exit 0 |

### 宣言ファイル集合 vs diff 照合 (L0-6)

`git diff --stat origin/main...dc2e210` = CONTRIBUTING.md / README.md / README.ja.md / README.zh.md / README.th.md / templates/ci/README.md の6ファイル（7 insertions, 6 deletions・2026-08-27 rebase 後に再実測）。宣言（#130 WIP コメント）と完全一致・宣言外ファイルなし。GLM 席はレビュー時 diff の SHA-256 突合まで実施し byte 一致を確認（rebase 後も range-diff `=` で同一内容）。

### 実装者 / レビュアー (L1-3 / L1-10 / L1-11)

- **Writer**: Alpha (Claude Fable 5, Claude Code) — 本 PR の実装・オーケストレーション。票には数えない
- **席決定**: `loom-seats --size S` 決定論出力 = 異種3席パネル（selection_fn_version 7・quorum GO）。高リスク領域該当なし（対外公開ゲート・課金・不可逆・権限境界のいずれにも非該当の docs 表記変更）
- **席 (requested / actual / verdict)**:
  1. GLM — requested glm-5.3 / actual glm-5.3 → **GO**（MINOR 1・INFO 2）。delta @1971913: MINOR **RESOLVED**・累積 **GO**
  2. Kimi — requested kimi-k3 / actual Kimi K3 (Moonshot CLI) → **GO**（MINOR 2・INFO 2）
  3. Grok — requested grok-4.6 / actual grok-4.6 → **GO**（INFO 3・CRITICAL/MAJOR 0）
- 全席 writer と異種・相互に異種（Zhipu / Moonshot / xAI）・fresh context・read-only・blind 並列。correlated-seats 該当なし
- **裁定**: Kimi+GLM が独立収束した MINOR（10x 課金の private リポ限定欠落）を採用 → delta `1971913`（1行）。引用行の精度（Kimi MINOR / Grok INFO）も同 delta で :17 header 併記に修正。他 findings は全て INFO・対応不要。blocking 0

### CI 状態 (T-4)

green — 候補 SHA `dc2e210`（rebase 後 head）で全ゲート pass（Test + Lint / gitleaks / History Check / PR Size / Risk Review Gate / repository state・2026-08-27 観測。test-lint は macOS レグ含む）。beacb66 / 1971913 時点でも全 pass。

### release 欄 (T-5)

- **release: N/A（類型① — 利用者が従う規範を含まない docs のみ）**。根拠: 条文（L2/L1/L0/FP/E/B/LC/R/T/PB）の文言・要求はゼロ変更（3席が axis 2 で独立監査）。変更は環境サポート表記（事実主張）と、既存 opt-out 機構（`run_macos` / `macos_skip_reason`・既定値不変）の費用注記のみ。「docs-only を N/A の口実にしない」条項は規範を密輸する docs を対象とし、本 diff は非該当 — 3席とも advisory で N/A ① 支持（Grok: 「N/A is the honest value, not an excuse」）。最終判断はオーナー決裁に委ねる（保守的に patch tag も否定しない: GLM/Grok 併記）
- **previous release**: v0.20.2（#129 repo-state caller・履行済み — annotated tag + GitHub Release 実在を 2026-08-27 に `gh release view v0.20.2` で再実測: publishedAt 2026-08-25T20:11:39Z。なお本 PR の merge 直前に #131〔RS-8 holder label・docs 4ファイル〕が main に入ったが、release 宣言を持たない docs merge であり T-5 の出荷相当列に入らない — fdh の Latest release は v0.20.2 のままであることを `gh release list` で再実測済み）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
