### PR TITLE
chore: pass EVTD_INBOX_TICKET_TOKEN through to the external-input watchdog

### DIFF
--- a/.github/workflows/external-input-caller.yml
+++ b/.github/workflows/external-input-caller.yml
@@ -34,3 +34,4 @@ jobs:
     secrets:
       TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
       TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
+      EVTD_INBOX_TICKET_TOKEN: ${{ secrets.EVTD_INBOX_TICKET_TOKEN }}


### PR DESCRIPTION
1-line secrets pass-through for the evtd wiring (caty-ai/.github#63 merged, v0.8.0; lane: caty-ai/evtd-inbox#1). Optional secret — no behavior change until the org secret EVTD_INBOX_TICKET_TOKEN is set; the 6h sweep covers the gap. File list: .github/workflows/external-input-caller.yml (1 insertion). This PR touches a workflow path and will wait for the owner's risk-reviewed label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
