### PR TITLE
docs(readme): correct project-status runtime claim (4 mirrors)

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -414,7 +414,7 @@ docs と templates の機械翻訳版（English / 简体中文 / ไทย）は
 - CI: ローカル caller から Test + Lint を含む reusable `@ci-v1` セット（5ゲート）を実行し、suite-count 照合を有効にしています。CI と同じエントリーポイントをローカルで実行するには `make test` と `make lint` を使います。
 - 検証済み環境: CI で `ubuntu-latest` と `macos-latest` を実行し、macOS でのローカル開発も行っています。WSL2 も対象です — `ubuntu-latest` レーンが検証しているのと同じ GNU 経路で動きます（clone は `/mnt/c` 配下ではなく Linux ファイルシステム側に）。
 - maturity: `stable` — 規範の正本です。
-- 既知の制約: runtime code を持たない docs-only リポジトリです。また、タイ語ミラーの既知のリンク2件を [#89](https://github.com/caty-ai/family-dev-handbook/issues/89) で追跡しています。
+- 既知の制約: 条文は docs のみですが、`templates/` と `scripts/` に配布用のゲートの型・検査スクリプト（YAML+Python）を含みます。また、タイ語ミラーの既知のリンク2件を [#89](https://github.com/caty-ai/family-dev-handbook/issues/89) で追跡しています。
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -417,7 +417,7 @@ The way in for proposals sits on the same rules.
 - CI: Local callers exercise the reusable `@ci-v1` set (five gates), including Test + Lint; suite-count reconciliation is enabled. Run the same CI entry points locally with `make test` and `make lint`.
 - 検証済み環境: `ubuntu-latest` and `macos-latest` are exercised in CI; macOS is also used for local development. WSL2 is in scope as well — it runs the same GNU path the `ubuntu-latest` lane verifies (clone inside the Linux filesystem, not `/mnt/c`).
 - maturity: `stable` — the normative canonical handbook.
-- 既知の制約: This is a docs-only repository with no runtime code; two known links in the Thai mirror are tracked in [#89](https://github.com/caty-ai/family-dev-handbook/issues/89).
+- 既知の制約: The statutes are docs-only; the repository also ships distributable gate templates and check scripts (YAML + Python) under `templates/` and `scripts/`. Two known links in the Thai mirror are tracked in [#89](https://github.com/caty-ai/family-dev-handbook/issues/89).
 
 ---
 

--- a/README.th.md
+++ b/README.th.md
@@ -417,7 +417,7 @@ flowchart TD
 - CI: caller ในรีโปจะเรียกใช้ชุด reusable `@ci-v1` (ห้า gate) ซึ่งรวม Test + Lint และเปิดใช้การกระทบยอด suite-count แล้ว หากต้องการใช้ entry point เดียวกับ CI ในเครื่อง ให้รัน `make test` และ `make lint`
 - 検証済み環境: CI รันบน `ubuntu-latest` และ `macos-latest` รวมทั้งมีการพัฒนาในเครื่องบน macOS นอกจากนี้ WSL2 ก็อยู่ในขอบเขตการรองรับด้วย — ใช้เส้นทาง GNU เดียวกับที่เลน `ubuntu-latest` ตรวจสอบไว้ (ให้ clone ลงในไฟล์ซิสเต็มฝั่ง Linux ไม่ใช่ใต้ `/mnt/c`)
 - maturity: `stable` — เป็นฉบับหลักเชิงบรรทัดฐาน
-- 既知の制約: เป็นรีโปเอกสารล้วนที่ไม่มี runtime code และลิงก์ที่ทราบปัญหาสองรายการในมิเรอร์ภาษาไทยกำลังติดตามอยู่ใน [#89](https://github.com/caty-ai/family-dev-handbook/issues/89)
+- 既知の制約: ข้อบัญญัติเป็นเอกสารล้วน แต่รีโปมีเทมเพลตเกตและสคริปต์ตรวจสอบสำหรับแจกจ่าย (YAML+Python) อยู่ใต้ `templates/` และ `scripts/` ด้วย ส่วนลิงก์ที่ทราบปัญหาสองรายการในมิเรอร์ภาษาไทยกำลังติดตามอยู่ใน [#89](https://github.com/caty-ai/family-dev-handbook/issues/89)
 
 ---
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -417,7 +417,7 @@ Epic 车道（`E-1`–`E-10`）是可选的。只有在负责人批准之后才�
 - CI: 本地 caller 会运行包含 Test + Lint 在内的 reusable `@ci-v1` 套件（五个关卡），并已启用 suite-count 对账。若要在本地运行与 CI 相同的入口，请使用 `make test` 和 `make lint`。
 - 検証済み環境: CI 会运行 `ubuntu-latest` 与 `macos-latest`，本地开发也使用 macOS。WSL2 同样在支持范围内 — 它运行的正是 `ubuntu-latest` 通道所验证的同一条 GNU 路径（请把仓库 clone 到 Linux 文件系统内，而不是 `/mnt/c` 下）。
 - maturity: `stable` — 规范性正本。
-- 既知の制約: 这是一个不含运行时代码的纯文档仓库；泰语镜像中的两个已知链接由 [#89](https://github.com/caty-ai/family-dev-handbook/issues/89) 跟踪。
+- 既知の制約: 条文均为纯文档，但仓库在 `templates/` 与 `scripts/` 下同时附带可分发的门禁模板与检查脚本（YAML+Python）；泰语镜像中的两个已知链接由 [#89](https://github.com/caty-ai/family-dev-handbook/issues/89) 跟踪。
 
 ---
 


### PR DESCRIPTION
Nightshift org-consistency finding `oc-2026-08-28-6869029197a5` (OC-F, 2026-08-28): the README Project-status line claims "This is a docs-only repository with no runtime code", but the tree contains executable Python check scripts (`scripts/test-gitleaks-validator.py`, `scripts/readme-check/inspect_readme.py`, `templates/publication-gate/check_publication_gate.py`, `templates/ci/scripts/assemble_review_comment.py`, `templates/seat-resolver/**`).

Issue-less lane: qualifies for the L1-1 exception (non-code md, one-line factual correction per file). PR route per L0-5 (no direct push to main).

## 完了記録

- **Done when**: the 既知の制約 line no longer claims "no runtime code" and instead matches the already-accurate FAQ row (README.md:164 "the rules are docs only; templates/ci holds distributable gate templates (YAML + scripts)"), in all four language mirrors.
  - PASS — evidence (2026-08-31): `grep -n "既知の制約" README*.md` now reads "statutes are docs-only; the repository also ships distributable gate templates and check scripts (YAML + Python) under templates/ and scripts/" (en; ja/zh/th equivalents). `grep -rn "docs-only repository with no runtime code" README*.md` → no matches.
- **候補SHA**: 0bd918ae78e8b64f04245fcbea6ede30d49f51c1 (= PR head)
- **宣言ファイル集合と diff の照合**: declared = README.md, README.ja.md, README.zh.md, README.th.md / diff = same 4 files, 1 line each — 一致
- **実装者**: Alpha (Claude Code, Fable 5) / **レビュアー**: critic subagent（requested/actual model=Opus・fresh-context・read-only）— **VERDICT: GO**（blocking 0件）。独立検証: git-trees API で head の Python 実行物5点＋YAML ゲート型の実在確認、4ミラーの意味等価（既知の制約行・#89 リンク保存・#89 OPEN 確認）、`make test`（declared=6 executed=6 skipped=0・readme-structure PASS）/`make lint` 全緑、旧文言の残存 grep ゼロ、diff は宣言4ファイルのみ。non-blocking 2件: ①「distributable」の係り（scripts/ は配布対象でない・文言微調整は任意）②**SECURITY.md:3 に同一の虚偽記述が残存** → follow-up [#138](https://github.com/caty-ai/family-dev-handbook/issues/138) で追跡（本 PR は宣言外を触らない）
- **CI**: 全 check green を確認（11/11 pass・test-lint / repo-state / risk-review-gate / gitleaks ほか）
- **release**: N/A — 類型①（利用者が従う規範を含まない docs のみ。条文 docs/ は無変更・Project status の事実記述の訂正のみ）
- **previous release**: v0.20.3（履行済み・GitHub Release あり）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
