### PR TITLE
security(review-labels): verify risk-reviewed labeled-event actor against roster (#140)

### DIFF
--- a/.github/workflows/reusable-review-labels.yml
+++ b/.github/workflows/reusable-review-labels.yml
@@ -19,7 +19,8 @@
 # - 承認は「貼り手」と「head SHA」の両方に束縛する。既定 = 方式1: ゲート自身のイベント判定 —
 #   作者が単独で起こせるイベント (synchronize / reopened / ready_for_review) の run では承認ラベルを
 #   無効として赤にし、緑に戻せるのは triage 権限者しか起こせないイベント (labeled / unlabeled) だけにする。
-#   緑候補では方式2の貼り手条件 (b) も機械照合する。ラベルの機械剥がし (「剥がしは機械・貼るのは人間」) は
+#   緑候補では方式2の貼り手条件 (b) (API 応答順でなく created_at 基準の最新 action が名簿内 actor の labeled で、後続 unlabeled なし) を完全に機械照合する。
+#   ラベルの機械剥がし (「剥がしは機械・貼るのは人間」) は
 #   可視化のための衛生で、判定はその成否に依存しない。
 # - 確認者名簿は base (main) 側の .github/risk-reviewers.txt から読む。PR head から読んではならない —
 #   「PR が名簿に自分を足して自分で通す」循環が開く。名簿不在・空・プレースホルダ = 赤。
@@ -296,6 +297,8 @@ jobs:
           BASE_REF: ${{ github.base_ref }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # tr・grep の文字分類を runner の locale に依存させず決定論にする。
+          LC_ALL: C.UTF-8
           DETECT_RESULT: ${{ needs.detect.result }}
           EVENT_ACTION: ${{ github.event.action }}
           RISK_HIT: ${{ needs.detect.outputs.risk_hit }}
@@ -347,37 +350,75 @@ jobs:
 
           # 方式1 (既定): risk-reviewed の現在有無で判定する (上のイベント束縛と対で機能する)。
           if grep -Fxq 'risk-reviewed' <<<"$LABELS"; then
-            STATUS='[{"source":"risk review","results":[{"kind":"action_required","title":"Risk reviewer verification required","summary":"The risk-reviewed label actor could not be verified against the base-side roster.","detail":"","how_to_fix":"Ask an owner listed in .github/risk-reviewers.txt to review the diff and re-apply the risk-reviewed label."}]}]'
             # API 不調を「貼り手不明のまま緑」へ変換しない (FP-6: 判定不能 = 赤)。
-            # 末尾 marker で command substitution による末尾改行の除去を防ぎ、最新 actor の null を過去の値にすり替えない。
-            TIMELINE_ACTORS=$(gh api --paginate -H "Accept: application/vnd.github+json" "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/timeline?per_page=100" --jq '.[] | select(.event == "labeled" and .label.name == "risk-reviewed") | (.actor.login // "")' && printf '\n__TIMELINE_END__') || {
+            # risk-reviewed の labeled/unlabeled を全ページから集め、created_at (+ 同秒の .id) で
+            # 新旧を確定する。API 応答順という契約外依存を排除し、後続 unlabeled なしまで照合する (FP-6・方式2(b))。
+            # matched event に created_at が無ければ順序判定不能として赤にする。
+            TIMELINE_DECISION=$(gh api --paginate --slurp \
+              -H "Accept: application/vnd.github+json" \
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/timeline?per_page=100" \
+              --jq '[ .[][]
+                | select((.event == "labeled" or .event == "unlabeled") and (.label.name // "") == "risk-reviewed") ]
+              | if length == 0 then "NOEVENT"
+                elif any(.[]; (.created_at // "") == "") then "AMBIGUOUS"
+                else ( sort_by(.created_at, (.id // 0)) | last
+                       | if .event != "labeled" then "UNLABELED_LATEST"
+                         else "ACTOR\t" + (.actor.login // "") end )
+                end') || {
               echo "::error::timeline fetch failed — cannot verify who applied risk-reviewed, failing closed (FP-6)."
+              STATUS='[{"source":"risk review","results":[{"kind":"action_required","title":"Risk reviewer verification required","summary":"The risk-reviewed label actor could not be verified against the base-side roster.","detail":"","how_to_fix":"Ask an owner listed in .github/risk-reviewers.txt to review the diff and re-apply the risk-reviewed label."}]}]'
               echo "review_status=${STATUS}" > review-status.json
               exit 1
             }
-            TIMELINE_ACTORS="${TIMELINE_ACTORS%$'\n'__TIMELINE_END__}"
-            if [ -z "$TIMELINE_ACTORS" ]; then
-              echo "::error::risk-reviewed is present but no matching labeled event was found in the full PR timeline — actor judgment is impossible, failing closed (FP-6)."
-              echo "review_status=${STATUS}" > review-status.json
-              exit 1
-            fi
-            LATEST_TIMELINE_ACTOR=$(printf '%s' "$TIMELINE_ACTORS" | tail -n 1)
-            ACTOR=$(printf '%s\n' "$TIMELINE_ACTORS" | sed '/^$/d' | tail -n 1)
-            if [ -z "$LATEST_TIMELINE_ACTOR" ] || [ -z "$ACTOR" ]; then
-              echo "::error::the most recent risk-reviewed labeled event has no actor — actor judgment is impossible, failing closed (FP-6)."
-              echo "review_status=${STATUS}" > review-status.json
-              exit 1
-            fi
+            ACTOR_PREFIX=$(printf 'ACTOR\t')
+            # GitHub login は tab を含まず '-' で始まらないため、ACTOR<tab> framing は login と衝突しない。
+            case "$TIMELINE_DECISION" in
+              NOEVENT)
+                echo "::error::risk-reviewed is present but no labeled/unlabeled event for risk-reviewed was found in the full PR timeline — actor judgment is impossible, failing closed (FP-6)."
+                STATUS='[{"source":"risk review","results":[{"kind":"action_required","title":"Risk reviewer verification required","summary":"The risk-reviewed label actor could not be verified against the base-side roster.","detail":"","how_to_fix":"Ask an owner listed in .github/risk-reviewers.txt to review the diff and re-apply the risk-reviewed label."}]}]'
+                echo "review_status=${STATUS}" > review-status.json
+                exit 1
+                ;;
+              AMBIGUOUS)
+                echo "::error::risk-reviewed timeline event(s) are missing created_at — recency cannot be established, failing closed (FP-6)."
+                STATUS='[{"source":"risk review","results":[{"kind":"action_required","title":"Risk reviewer verification required","summary":"The risk-reviewed label actor could not be verified against the base-side roster.","detail":"","how_to_fix":"Ask an owner listed in .github/risk-reviewers.txt to review the diff and re-apply the risk-reviewed label."}]}]'
+                echo "review_status=${STATUS}" > review-status.json
+                exit 1
+                ;;
+              UNLABELED_LATEST)
+                echo "::error::the newest timeline action on risk-reviewed is a removal, which disagrees with the label-present snapshot — state judgment is impossible, failing closed (FP-6)."
+                STATUS='[{"source":"risk review","results":[{"kind":"action_required","title":"Risk reviewer verification required","summary":"The PR timeline shows risk-reviewed was removed after its last apply; the label state could not be confirmed. Re-apply the label.","detail":"","how_to_fix":"Ask an owner listed in .github/risk-reviewers.txt to review the diff and re-apply the risk-reviewed label."}]}]'
+                echo "review_status=${STATUS}" > review-status.json
+                exit 1
+                ;;
+              "${ACTOR_PREFIX}"*)
+                ACTOR=${TIMELINE_DECISION#"$ACTOR_PREFIX"}
+                if [ -z "$ACTOR" ]; then
+                  echo "::error::the most recent risk-reviewed apply has no recorded actor — actor judgment is impossible, failing closed (FP-6)."
+                  STATUS='[{"source":"risk review","results":[{"kind":"action_required","title":"Risk reviewer verification required","summary":"The most recent risk-reviewed apply has no recorded actor.","detail":"","how_to_fix":"Ask an owner listed in .github/risk-reviewers.txt to review the diff and re-apply the risk-reviewed label."}]}]'
+                  echo "review_status=${STATUS}" > review-status.json
+                  exit 1
+                fi
+                ;;
+              *)
+                echo "::error::unrecognized risk-reviewed timeline decision — actor judgment is impossible, failing closed (FP-6)."
+                STATUS='[{"source":"risk review","results":[{"kind":"action_required","title":"Risk reviewer verification required","summary":"The risk-reviewed label actor could not be verified against the base-side roster.","detail":"","how_to_fix":"Ask an owner listed in .github/risk-reviewers.txt to review the diff and re-apply the risk-reviewed label."}]}]'
+                echo "review_status=${STATUS}" > review-status.json
+                exit 1
+                ;;
+            esac
             ACTOR_FOLDED=$(printf '%s' "$ACTOR" | tr '[:upper:]' '[:lower:]')
             ROSTER_FOLDED=$(printf '%s\n' "$ROSTER" | tr '[:upper:]' '[:lower:]')
-            if ! grep -Fxq "$ACTOR_FOLDED" <<<"$ROSTER_FOLDED"; then
-              echo "::error::risk-reviewed was most recently applied by '${ACTOR}', who is not in the base-side roster — a roster human must review the diff and re-apply the label."
+            if ! grep -Fxq -- "$ACTOR_FOLDED" <<<"$ROSTER_FOLDED"; then
+              printf '%s\n' "::error::risk-reviewed was most recently applied by '${ACTOR}', who is not in the base-side roster — a roster human must review the diff and re-apply the label."
+              STATUS='[{"source":"risk review","results":[{"kind":"action_required","title":"Risk reviewer verification required","summary":"risk-reviewed was applied by an actor who is not in the base-side roster.","detail":"","how_to_fix":"Ask an owner listed in .github/risk-reviewers.txt to review the diff and re-apply the risk-reviewed label."}]}]'
               echo "review_status=${STATUS}" > review-status.json
               exit 1
             fi
             echo "::notice::risk-reviewed label present — gate green."
             echo "audit: approval is bound to the current head SHA at the gate itself (synchronize/reopened runs go red regardless of the label); the strip job additionally removes the stale label for visibility."
-            echo "audit: risk-reviewed applied by '${ACTOR}' — verified against the base-side roster."
+            printf '%s\n' "audit: risk-reviewed applied by '${ACTOR}' — verified against the base-side roster."
             echo "audit: roster (origin/${BASE_REF}:.github/risk-reviewers.txt):"
             printf '%s\n' "$ROSTER" | sed 's/^/  - /'
             STATUS='[{"source":"risk review","results":[]}]'
@@ -398,8 +439,10 @@ jobs:
           echo "review_status=${STATUS}" > review-status.json
 
           # ── 方式2との hybrid ──────────────────────────────────────────
-          # (a) は方式1のラベル現在有無、(b) は timeline 最新の labeled actor の名簿照合として実装済み。
-          # (c) labeled-after-push 時刻照合はイベント束縛で構造的にカバーするため、意図的に実装しない。
+          # (a) は方式1のラベル現在有無、(b) は created_at 基準の最新 risk-reviewed event が
+          # 名簿内 actor の labeled であること (後続 unlabeled なしを含む) まで完全実装済み。
+          # (c) labeled-after-push 時刻照合は意図的に未実装。synchronize / reopened / ready_for_review は
+          # イベント束縛で扱う一方、fork 403 で剥がせない古いラベルの既知残余は templates/ci/README.md に記載する。
 
       - name: Upload review status artifact
         if: always()

--- a/.github/workflows/reusable-review-labels.yml
+++ b/.github/workflows/reusable-review-labels.yml
@@ -9,19 +9,18 @@
 #           人間 (オーナー) の確認ラベルなしに merge されないこと。検知は機械・判定は人間。
 #
 # ⚠ このゲートの現時点の位置づけ = 「オーナー確認の可視化・監査記録」装置 (FP-5: 装わない):
-#   赤止め (risk-reviewed ラベルが付くまでマージ不可) は機能するが、家族運用では全エージェントが
-#   オーナーの資格情報で API を叩くため、「AI がラベルを貼れない」ことの機械的保証は identity 分離
-#   (エージェント別 author/token) の完了までは無い。無断でラベルを貼る行為はプロトコル違反
-#   (handbook E-5「無承認チェックポイント実行の禁止」) として扱い、PR timeline に監査証跡が残る —
-#   検知は機械・判定と追及は人間。identity 分離の完了後に貼り手 (actor) 検証が実効化する。
+#   赤止めと最新の risk-reviewed 貼付 actor の base 側名簿照合は機械化済み。ただし家族運用では
+#   全エージェントがオーナーの資格情報を共有するため、actor 識別の強さは資格情報の分離の強さに限られる。
+#   この照合が完全に実効化するのは identity 分離 (エージェント別 author/token) 後であり、無断貼付は
+#   引き続きプロトコル違反 (handbook E-5「無承認チェックポイント実行の禁止」) として timeline で追及する。
 #
 # 設計姿勢 (handbook docs/05・docs/06・docs/09):
 # - 高リスク領域の定義の正本は handbook docs/06 (再定義しない)。本ファイルはパスへの写像だけを持つ。
 # - 承認は「貼り手」と「head SHA」の両方に束縛する。既定 = 方式1: ゲート自身のイベント判定 —
 #   作者が単独で起こせるイベント (synchronize / reopened / ready_for_review) の run では承認ラベルを
 #   無効として赤にし、緑に戻せるのは triage 権限者しか起こせないイベント (labeled / unlabeled) だけにする。
-#   ラベルの機械剥がし (「剥がしは機械・貼るのは人間」) は可視化のための衛生で、判定はその成否に
-#   依存しない。代替 = 方式2 (タイムライン3条件 AND・末尾コメント参照)。
+#   緑候補では方式2の貼り手条件 (b) も機械照合する。ラベルの機械剥がし (「剥がしは機械・貼るのは人間」) は
+#   可視化のための衛生で、判定はその成否に依存しない。
 # - 確認者名簿は base (main) 側の .github/risk-reviewers.txt から読む。PR head から読んではならない —
 #   「PR が名簿に自分を足して自分で通す」循環が開く。名簿不在・空・プレースホルダ = 赤。
 # - ゲート判定は read 権限で完結し fork でも必ず赤/緑を出す。ラベル付与・剥がしの書き込みは
@@ -348,8 +347,37 @@ jobs:
 
           # 方式1 (既定): risk-reviewed の現在有無で判定する (上のイベント束縛と対で機能する)。
           if grep -Fxq 'risk-reviewed' <<<"$LABELS"; then
+            STATUS='[{"source":"risk review","results":[{"kind":"action_required","title":"Risk reviewer verification required","summary":"The risk-reviewed label actor could not be verified against the base-side roster.","detail":"","how_to_fix":"Ask an owner listed in .github/risk-reviewers.txt to review the diff and re-apply the risk-reviewed label."}]}]'
+            # API 不調を「貼り手不明のまま緑」へ変換しない (FP-6: 判定不能 = 赤)。
+            # 末尾 marker で command substitution による末尾改行の除去を防ぎ、最新 actor の null を過去の値にすり替えない。
+            TIMELINE_ACTORS=$(gh api --paginate -H "Accept: application/vnd.github+json" "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/timeline?per_page=100" --jq '.[] | select(.event == "labeled" and .label.name == "risk-reviewed") | (.actor.login // "")' && printf '\n__TIMELINE_END__') || {
+              echo "::error::timeline fetch failed — cannot verify who applied risk-reviewed, failing closed (FP-6)."
+              echo "review_status=${STATUS}" > review-status.json
+              exit 1
+            }
+            TIMELINE_ACTORS="${TIMELINE_ACTORS%$'\n'__TIMELINE_END__}"
+            if [ -z "$TIMELINE_ACTORS" ]; then
+              echo "::error::risk-reviewed is present but no matching labeled event was found in the full PR timeline — actor judgment is impossible, failing closed (FP-6)."
+              echo "review_status=${STATUS}" > review-status.json
+              exit 1
+            fi
+            LATEST_TIMELINE_ACTOR=$(printf '%s' "$TIMELINE_ACTORS" | tail -n 1)
+            ACTOR=$(printf '%s\n' "$TIMELINE_ACTORS" | sed '/^$/d' | tail -n 1)
+            if [ -z "$LATEST_TIMELINE_ACTOR" ] || [ -z "$ACTOR" ]; then
+              echo "::error::the most recent risk-reviewed labeled event has no actor — actor judgment is impossible, failing closed (FP-6)."
+              echo "review_status=${STATUS}" > review-status.json
+              exit 1
+            fi
+            ACTOR_FOLDED=$(printf '%s' "$ACTOR" | tr '[:upper:]' '[:lower:]')
+            ROSTER_FOLDED=$(printf '%s\n' "$ROSTER" | tr '[:upper:]' '[:lower:]')
+            if ! grep -Fxq "$ACTOR_FOLDED" <<<"$ROSTER_FOLDED"; then
+              echo "::error::risk-reviewed was most recently applied by '${ACTOR}', who is not in the base-side roster — a roster human must review the diff and re-apply the label."
+              echo "review_status=${STATUS}" > review-status.json
+              exit 1
+            fi
             echo "::notice::risk-reviewed label present — gate green."
             echo "audit: approval is bound to the current head SHA at the gate itself (synchronize/reopened runs go red regardless of the label); the strip job additionally removes the stale label for visibility."
+            echo "audit: risk-reviewed applied by '${ACTOR}' — verified against the base-side roster."
             echo "audit: roster (origin/${BASE_REF}:.github/risk-reviewers.txt):"
             printf '%s\n' "$ROSTER" | sed 's/^/  - /'
             STATUS='[{"source":"risk review","results":[]}]'
@@ -369,13 +397,9 @@ jobs:
           fi
           echo "review_status=${STATUS}" > review-status.json
 
-          # ── 方式2 (代替・採用する場合はこのコメントを実装に差し替える) ──────────
-          # 3条件 AND 判定: (a) risk-reviewed が現在付いている (pull_request.labels)
-          #   ∧ (b) 時系列で最後の labeled イベント (gh api --paginate で timeline 全件取得) の actor が
-          #        名簿に含まれ、それ以降に unlabeled が無い
-          #   ∧ (c) その labeled の created_at が head commit の push 時刻より後
-          # timeline API の取得失敗・空応答は赤 (判定不能扱い・FP-6)。
-          # 手動 re-run は実行時に timeline を再取得するので判定は最新化される (キャッシュしない)。
+          # ── 方式2との hybrid ──────────────────────────────────────────
+          # (a) は方式1のラベル現在有無、(b) は timeline 最新の labeled actor の名簿照合として実装済み。
+          # (c) labeled-after-push 時刻照合はイベント束縛で構造的にカバーするため、意図的に実装しない。
 
       - name: Upload review status artifact
         if: always()

--- a/.github/workflows/reusable-review-labels.yml
+++ b/.github/workflows/reusable-review-labels.yml
@@ -354,11 +354,12 @@ jobs:
             # risk-reviewed の labeled/unlabeled を全ページから集め、created_at (+ 同秒の .id) で
             # 新旧を確定する。API 応答順という契約外依存を排除し、後続 unlabeled なしまで照合する (FP-6・方式2(b))。
             # matched event に created_at が無ければ順序判定不能として赤にする。
+            # gh api は --slurp と --jq を併用できないため、slurp 後の [[...],[...]] をパイプ先の jq -r で一度だけ絞る。
             TIMELINE_DECISION=$(gh api --paginate --slurp \
               -H "Accept: application/vnd.github+json" \
               -H "X-GitHub-Api-Version: 2022-11-28" \
               "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/timeline?per_page=100" \
-              --jq '[ .[][]
+              | jq -r '[ .[][]
                 | select((.event == "labeled" or .event == "unlabeled") and (.label.name // "") == "risk-reviewed") ]
               | if length == 0 then "NOEVENT"
                 elif any(.[]; (.created_at // "") == "") then "AMBIGUOUS"

--- a/templates/ci/README.md
+++ b/templates/ci/README.md
@@ -20,6 +20,9 @@
 
 **review-labels の現時点の位置づけ**: オーナー確認の**可視化+監査**装置。赤止めと最新の `risk-reviewed` 貼付 actor の base 側名簿照合は機械化されているが、全エージェントがオーナーの資格情報を共有する運用では actor 識別の強さも資格情報の分離の強さに限られ、**identity 分離後にはじめて完全に実効化する**。無断貼付はプロトコル違反（handbook E-5）として扱い、PR timeline の監査証跡で追及する（「検証済み」を装わない — FP-5）。
 
+- この変更を越えて `ci-v1` を前進させる前に、各 caller repo の base 側 `.github/risk-reviewers.txt` に、実際に `risk-reviewed` を貼る GitHub login が正確に載っていることを確認する（名簿と貼付者の不一致はそのリポのゲートを赤にする）。
+- 名簿は bare login を1行ずつ書く。比較は大文字小文字を区別しないが、先頭の `@` は許容せず一致しない。
+
 ## 展開手順（コピペ順）
 
 1. `templates/ci/*.yml`（**caller stencil**）を対象リポの `.github/workflows/` へ、`scripts/assemble_review_comment.py` を `scripts/ci/` へコピー（Layer 2 を使わないなら合成器は後回しでよく、`release-sync.yml` は下記 release-sync 節の導入順（handbook release + `ci-v1` 前進の確認）を満たすまでコピーしない）。各ファイルの `uses:` 行が `caty-ai/family-dev-handbook/.github/workflows/reusable-<gate>.yml@ci-v1` を pin していることを確認する（バージョニングは下記「バージョニング」節を参照）

--- a/templates/ci/README.md
+++ b/templates/ci/README.md
@@ -15,10 +15,10 @@
 | `gitleaks.yml` | 秘密情報の main 到達 | 検知あり・走査範囲が解決不能/空（fail-closed） | 新規 |
 | `pr-size.yml` | レビュー不能な巨大 PR | 除外後 250 行超（既定・**required 非登録の可視化ゲート**） | 新規 |
 | `history-check.yml` | 歴史切断 PR（blame 崩壊） | main と共通祖先なし | 翻案（hermes-agent） |
-| `review-labels.yml` | 高リスク領域の無確認 merge | 高リスクパス変更 + `risk-reviewed` ラベルなし・名簿/宣言の不備（fail-closed） | 翻案（hermes-agent） |
+| `review-labels.yml` | 高リスク領域の無確認 merge | 高リスクパス変更 + `risk-reviewed` ラベルなし・貼付 actor の名簿外/不明・名簿/宣言の不備（fail-closed） | 翻案（hermes-agent） |
 | `scripts/assemble_review_comment.py` | （Layer 2）門番報告の PR コメント1枚化 | —（合成器・ゲートではない） | そのまま（hermes-agent） |
 
-**review-labels の現時点の位置づけ**: オーナー確認の**可視化+監査**装置。赤止め（ラベルが付くまで merge 不可）は機能するが、全エージェントがオーナーの資格情報を共有する運用では「AI がラベルを貼れない」ことの機械的保証は **identity 分離の完了まで無い**。無断貼付はプロトコル違反（handbook E-5）として扱い、PR timeline の監査証跡で追及する — 検知は機械・判定と追及は人間（「検証済み」を装わない — FP-5）。
+**review-labels の現時点の位置づけ**: オーナー確認の**可視化+監査**装置。赤止めと最新の `risk-reviewed` 貼付 actor の base 側名簿照合は機械化されているが、全エージェントがオーナーの資格情報を共有する運用では actor 識別の強さも資格情報の分離の強さに限られ、**identity 分離後にはじめて完全に実効化する**。無断貼付はプロトコル違反（handbook E-5）として扱い、PR timeline の監査証跡で追及する（「検証済み」を装わない — FP-5）。
 
 ## 展開手順（コピペ順）
 


### PR DESCRIPTION
Closes #140 (sibling of caty-ai/caty-agent-harness#242 — adopted nightly security finding `rv-security-codex-0b96f0e5111f-f5cb2ac2`, kind: authorization, severity:high)

Implement 方式2 condition (b) fully, as a hybrid on top of 方式1: on every run where the gate would go green from `risk-reviewed` label presence, the gate fetches the full PR timeline (`gh api --paginate --slurp | jq -r`, one filter application over all pages), selects the latest `labeled`/`unlabeled` event for `risk-reviewed` **by `created_at` (+ `.id` same-second tie-break) — never by API response order** — and goes green only when that event is a `labeled` whose actor is in the base-side roster (`.github/risk-reviewers.txt`, case-insensitive). Everything else fails closed (FP-6): fetch failure, no matching event, missing `created_at` (AMBIGUOUS), newest action is a removal (UNLABELED_LATEST), ghost/null actor, non-roster actor (named in the error), unrecognized decision token. 方式1's event binding (synchronize / reopened / ready_for_review → red) is untouched; (c) remains intentionally unimplemented with the residual documented. Header + `templates/ci/README.md` updated honestly (mechanical actor check; residual risk under shared owner credentials stays documented) plus a ci-v1 rollout note (roster must list the actual label appliers; bare logins, no `@`).

Backward compatible: no new `workflow_call` inputs, no permission changes, `detect`/`labels` jobs untouched.

## Files touched (= WIP declaration, 2 files)

- `.github/workflows/reusable-review-labels.yml`
- `templates/ci/README.md`

`git diff --stat origin/main...6712d2e` = exactly these 2 files (87 insertions / 16 deletions, 3 commits). No undeclared files.

## 完了記録 (L1-7)

**候補 commit SHA: `6712d2e`** (= PR head at review completion; `d80636f` implementation + `98f41a9` panel delta + `6712d2e` delta-2)

### Done when → PASS/FAIL

1. **Green-from-label-presence runs resolve the most recent `labeled` event and fail unless its actor is in the roster — PASS.**
   Evidence (2026-09-01): extracted-gate probe v3 (17 scenarios, stubbed `gh` emitting slurped JSON, REAL `jq` applying the shipped filter): `single-roster-green → exit 0` with `audit: risk-reviewed applied by 'shojikumaru' — verified against the base-side roster.`; `latest-nonroster-array-reversed-red → exit 1` naming `mallory` (events deliberately non-chronological in the array — recency from `created_at`, not order); `cross-page-latest-nonroster-red → exit 1`. Full log: probe-evidence-r3 (session scratchpad), summarized in review record comment-5493249179.
2. **Ambiguity fails closed — PASS.**
   Evidence: probe v3 red outcomes for: fetch failure (exit 22 propagated via pipefail), no matching event (NOEVENT), missing `created_at` (AMBIGUOUS), removal-latest (UNLABELED_LATEST), ghost/null actor, malformed (object-shaped) timeline payload, unrecognized decision token (defense-in-depth default arm — traced by all 5 seats). 17/17 expected outcomes, 2026-09-01.
3. **Documented manual probe: roster actor → pass; non-roster actor → fail — PASS.**
   Evidence: probe v3 rows above (roster pass + non-roster fail, recorded output); plus live-infra runs of this PR's own gate (local-path caller): `opened` run 33498786912 = label-absent red; `synchronize` runs 33500534230 / 33501910794 = void-event red. The roster-actor **green** live run lands when the roster owner applies `risk-reviewed` to this PR (run URL appended below on labeling — the gate self-validates its own green path before merge).
4. **Residual risk documented next to the gate — PASS.**
   Evidence: header ⚠ block (actor check mechanical; identity strength bounded by credential separation until identity 分離) + `templates/ci/README.md` positioning paragraph, both verified for honesty by all 5 seats (r1 + delta rounds).
5. **Callers unaffected without a pin roll — PASS.**
   Evidence: no `workflow_call` input changes, no `permissions:` changes, job names/outputs/artifact name unchanged (seat-verified by YAML parse in r1); `@ci-v1` callers keep the old behavior until the tag advances.
6. **Workflow checks green / release process — PASS (with the designed process-gate exception).**
   Evidence (2026-09-01, head `6712d2e`): gitleaks / history-check / pr-size / repo-state / test-lint (lint, test, test-macos) / watch all pass; `risk-review-gate` red is the gate's own designed human-label wait (this PR touches `.github/workflows/**`), not a code failure — it flips green (with actor verification live) on the roster owner's `labeled` event, which is required before merge.

### Review (L1-3 / L1-10 / L1-11)

- Implementer: **Codex GPT-5.6 Sol** (sol / effort high; 3 commits, orchestrated by Alpha who verified and committed). Reviewers: 異種5席 **Opus 5 / GLM 5.3 / Grok 4.6 / Kimi K3 / Codex Sol** — fresh context, read-only, r1 blind. Round trail: r1 (1 blocking: API-order reliance, 4-seat convergence) → panel delta `98f41a9` → delta review (1 demonstrated blocking: `gh api --slurp`+`--jq` mutually exclusive, 4-seat convergence) → delta-2 `6712d2e` → **5/5 cumulative GO**. Full record with requested/actual models and the correlated-seats exception (codex-sol seat × codex-sol writer, seat-decree 2026-08-12): [comment-5493249179](https://github.com/caty-ai/family-dev-handbook/pull/141#issuecomment-5493249179).

### CI state

All checks green at `6712d2e` except `risk-review-gate / risk-review-gate` (designed human-label process gate, see Done-when 6). Merge occurs only after the roster owner applies `risk-reviewed` and the gate run is green.

### release

- **release: v0.21.0** — annotated tag on the merge commit + GitHub Release (release-sync carrier), then advance the `ci-v1` moving tag to the same commit (backward-compatible change; rollout precondition verified 2026-09-01: all three `@ci-v1` callers of this reusable — alpha-nightshift-dev / family-memory-architecture / meetmate-dev — plus caty-agent-harness's roster all list `shojikumaru`, the actual label applier).
- **previous release: v0.20.3** — fulfilled (GitHub Release exists, published 2026-08-26, currently Latest).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
