### PR TITLE
fix(publication-gate): fail closed on non-UTF-8 text, --registry omission, bare-@ URLs (#97, #98)

### DIFF
--- a/templates/publication-gate/README.md
+++ b/templates/publication-gate/README.md
@@ -208,7 +208,7 @@ summary は必ず `enumeration: git` または `enumeration: rglob-fallback` と
 ## 2026-09 改訂（#97 / #98）— 採用リポの再コピー差分
 
 `2d2d4b3` の byte-identical copy を保持している採用リポは、この変更を含む handbook release
-（この PR の merge 時に `v0.22.0` として切る）の checker を再コピーし、次の caller-visible な差分を取り込む。
+（この PR の merge 時に `v0.24.0` として切る）の checker を再コピーし、次の caller-visible な差分を取り込む。
 
 - 既知の binary suffix または exact filename `.DS_Store` 以外のファイルが UTF-8 でなければ、
   `source-read: ... is not valid UTF-8 text (fail-closed)` で赤になる。既知の binary file は decode に
@@ -223,7 +223,7 @@ summary は必ず `enumeration: git` または `enumeration: rglob-fallback` と
   `.publication-denylist` は e-mail ルールを**必ず**含めること。sample には `email-address` ルールを同梱し、
   sample を使わず自前 denylist を書く場合も同等のルールを載せる。
 - nested host を含む URL 候補の personal-url 検査は、上記「個人用 URL」節を参照する。
-- 再コピー対象は、この変更を含む handbook release（この PR の merge 時に `v0.22.0` として切る）。
+- 再コピー対象は、この変更を含む handbook release（この PR の merge 時に `v0.24.0` として切る）。
 
 ## family-os / organization `.github` からの移行
 

--- a/templates/publication-gate/README.md
+++ b/templates/publication-gate/README.md
@@ -20,11 +20,13 @@ required status check に登録して初めて「保護済み」と扱う。
 | SVG 状態 | README の表示と台帳の公開状態が食い違わないこと | 検査を skip し、notice を出す |
 | label whitelist の stale | 一時的な例外が台帳変更後も残らないこと | 検査を skip し、notice を出す |
 
-`--registry` は任意。省略した場合も denylist と個人用 URL の検査は実行し、確認不能な
-4検査を黙って緑にせず、それぞれ skip notice を出す。corpus のアンカーは、レジストリ有りなら
-指定した JSON ファイル、無しなら `<root>/README.md` へ fallback する。カレントディレクトリ下の別 README を
-偶然拾って判定の起点にはしない。レジストリなしで `<root>/README.md` も無い場合は、corpus floor を
-確立できないため赤になる。
+通常検査では `--registry` か `--no-registry` のどちらかを明示する。両方を省略した場合と、両方を
+指定した場合は設定不備として赤になる。`--no-registry` を明示した場合も denylist と個人用 URL の
+検査は実行し、確認不能な4検査を黙って緑にせず、それぞれ skip notice を出す。さらに
+`<root>/registry/modules.json` が存在するのに `--no-registry` を指定した場合も赤になる。corpus の
+アンカーは、レジストリ有りなら指定した JSON ファイル、明示的なレジストリなしなら
+`<root>/README.md` へ fallback する。カレントディレクトリ下の別 README を偶然拾って判定の起点には
+しない。レジストリなしで `<root>/README.md` も無い場合は、corpus floor を確立できないため赤になる。
 
 個人用 URL は URL 候補を解析して host を正規化してから照合する。`github.com/<slug>` に加え、
 `github.com:443/<slug>`、`github.com./<slug>`、`gist.github.com/<slug>`、
@@ -44,15 +46,23 @@ required status check に登録して初めて「保護済み」と扱う。
    ```bash
    cp templates/publication-gate/fixtures/sample.publication-denylist <target-repo>/.publication-denylist
    ```
-3. CI に通常検査を配線する。レジストリを持つリポは `--registry` も渡す。
+3. CI に通常検査を配線する。レジストリを持つリポは `--registry` を渡す。
    ```bash
    python3 -B tools/check_publication_gate.py \
      --root . \
      --account-slug "$PUBLICATION_ACCOUNT_SLUG" \
      --registry path/to/modules.json
    ```
-   レジストリを使わないリポは最後の2引数を省略する。機微パターンを CI secret から
-   注入する場合は `--denylist "$PUBLICATION_DENYLIST_PATH"` も渡す。`--registry` を省略しても
+   レジストリを持たないリポは、代わりに opt-out を明示する。
+   ```bash
+   python3 -B tools/check_publication_gate.py \
+     --root . \
+     --account-slug "$PUBLICATION_ACCOUNT_SLUG" \
+     --no-registry
+   ```
+   `--registry` と `--no-registry` の両方を省略すると赤になる。また、
+   `<root>/registry/modules.json` が存在するリポで `--no-registry` を渡しても赤になる。機微パターンを
+   CI secret から注入する場合は `--denylist "$PUBLICATION_DENYLIST_PATH"` も渡す。
    `--account-slug` は省略できない。個人用 URL 検査は通常実行で常に有効で、slug 未指定は
    ゲートの設定不備として赤になる。
 4. checker の self-test と導入先のテストを同じ CI job か依存 job で実行し、その status
@@ -117,15 +127,17 @@ PATH<TAB>EXACT_LINE
 `PATH` と、そのファイル内で許可する `EXACT_LINE` の完全一致だけを免除する。このファイルは
 **言い訳だけを追加する** allowlist であり、新しい問題を検出するポリシーではない。したがって不在時は
 fail-open（免除なしとして継続）でよい。denylist の不存を赤にするのとは非対称だが、意図的な設計である。
-`--registry` が無い場合は whitelist-staleness を判定できないため、その検査は notice 付きで skip する。
+`--no-registry` を明示した場合は whitelist-staleness を判定できないため、その検査は notice 付きで
+skip する。
 
 ## CLI
 
 | 引数 | 必須性 / 既定値 | 意味 |
 |---|---|---|
-| `--root PATH` | 任意、既定 `.` | 検査対象リポのルート。ポリシーファイルと、レジストリ省略時の `README.md` のアンカー |
+| `--root PATH` | 任意、既定 `.` | 検査対象リポのルート。ポリシーファイルと、`--no-registry` 時の `README.md` のアンカー |
 | `--account-slug SLUG` | 通常検査で必須、既定なし | 公開物に残してはいけない個人アカウントの slug。未指定は赤 |
-| `--registry PATH` | 任意、既定なし | 公開リポ台帳の JSON ファイル。無い場合は台帳依存の4検査だけを notice 付きで skip |
+| `--registry PATH` | `--no-registry` と二者択一 | 公開リポ台帳の JSON ファイル。相対パスは root 基準 |
+| `--no-registry` | `--registry` と二者択一、既定 `false` | 公開台帳を持たないリポであることを明示し、台帳依存の4検査を notice 付きで skip |
 | `--denylist PATH` | 任意、既定 `<root>/.publication-denylist` | 外部 denylist。相対パスは root 基準。root 内なら明示指定したファイルもスキャンから path-exclude |
 | `--selftest` | 任意、既定 `false` | 内蔵 fixture で parser・検出・fail posture を検査して終了 |
 
@@ -150,9 +162,12 @@ __pycache__
 ```
 
 列挙された regular file は suffix やファイル名で選別せず、`.env`、`LICENSE`、`Dockerfile`、`.txt`、
-拡張子なしもすべて UTF-8 decode を試す。decode できないファイルは binary としてスキャンを飛ばすが、
-`binary files skipped: N` に必ず集計する。Git mode の symlink は Git が公開する readlink text を検査する。
-`rglob-fallback` は symlink を follow せず、`symlinks skipped: N` に集計する。
+拡張子なしもすべて UTF-8 decode を試す。既知の text suffix または拡張子なしのファイルを decode
+できなければ `source-read: ... is not valid UTF-8 text (fail-closed)` で赤にする。それ以外の genuinely
+binary な suffix はスキャンを飛ばし、`binary files skipped: N` に集計した直後へ
+`  skipped (binary): <relative path>` と1ファイル1行で名前も表示する。Git mode の symlink は Git が
+公開する readlink text を検査する。`rglob-fallback` は symlink を follow せず、
+`symlinks skipped: N` に集計する。
 
 summary は必ず `enumeration: git` または `enumeration: rglob-fallback` と、
 `denylist rules loaded : N` を表示する。raw view の hit は raw text の行番号を使い、percent/HTML decode 後に
@@ -162,17 +177,36 @@ summary は必ず `enumeration: git` または `enumeration: rglob-fallback` と
 埋め込まれている。disk 上の `fixtures/` は人間向け資料であり selftest の依存ではないため、checker の
 `.py` だけを別ディレクトリへコピーしても `--selftest` は完走する。
 
+## 2026-09 改訂（#97 / #98）— 採用リポの再コピー差分
+
+`2d2d4b3` の byte-identical copy を保持している採用リポは、`v0.22.0` で配布される checker を
+再コピーし、次の caller-visible な差分を取り込む。
+
+- text suffix または拡張子なしのファイルが UTF-8 でなければ、
+  `source-read: ... is not valid UTF-8 text (fail-closed)` で赤になる。genuinely binary な suffix は従来どおり
+  skip するが、`binary files skipped:` の直下へ相対パスを列挙する。caller 側の
+  `binary files skipped: 0` grep guard は不要になったが、残しても害はない。
+- `--registry` の省略は赤になる。レジストリを持たない caller は `--no-registry` を追加する。
+  `registry/modules.json` が disk 上にある状態での `--no-registry` も赤になる。
+- bare `@github.com/<slug>/<repo>` と `@github.com/<slug>` も personal-url として検出する。
+  `local@github.com/...` は引き続き URL 検査ではなく e-mail denylist rule の担当とする。
+- 再コピー対象は、この変更を含む handbook release `v0.22.0`。
+
 ## family-os / organization `.github` からの移行
 
 `family-os` と organization `.github` にある局所コピーは、この stencil の挙動を先に確定した後、
 後続の **B9 lane** で置き換える。このテンプレート導入と既存リポの移行を同じ diff で混ぜない。
 
-移行時の意図的な差分は2つ。
+移行時の意図的な差分は4つ。
 
 - 旧コピーの email masking のバグは修正済みで、新チェッカーの方が**厳格**。以前通っていた表記が
   新しく赤になった場合、検知退行ではなく bug fix の結果として対象テキストを直す。
 - 外部 `.publication-denylist` は必須。先にファイルを配置・カスタマイズせず checker だけを切り替えると、
   ゲートは意図的に赤のままになる。
+- text suffix または拡張子なしのファイルの decode failure は binary skip にせず赤にする。これは旧コピーの
+  fail-closed な挙動と一致し、template 化の途中で生じた検査姿勢の緩みを戻す差分である。
+- 通常実行では `--registry` か `--no-registry` の明示が必須。レジストリを持たない移行先は CI と
+  ローカルの呼び出しへ `--no-registry` を追加する。
 
 移行 PR では `--selftest`、対象リポの `make test`、通常 CLI の実行結果、CI status check の
 required 登録を証拠として残す。

--- a/templates/publication-gate/README.md
+++ b/templates/publication-gate/README.md
@@ -161,13 +161,24 @@ node_modules
 __pycache__
 ```
 
-列挙された regular file は suffix やファイル名で選別せず、`.env`、`LICENSE`、`Dockerfile`、`.txt`、
-拡張子なしもすべて UTF-8 decode を試す。既知の text suffix または拡張子なしのファイルを decode
-できなければ `source-read: ... is not valid UTF-8 text (fail-closed)` で赤にする。それ以外の genuinely
-binary な suffix はスキャンを飛ばし、`binary files skipped: N` に集計した直後へ
+列挙された regular file は suffix やファイル名で選別せず、`.env.local`、`.cs`、`.csproj`、`.ipynb`、
+`.txt`、`.csv`、`LICENSE`、`Dockerfile`、拡張子なしもすべて先に UTF-8 decode を試す。decode
+できなかった場合だけ、明示した既知の binary suffix または exact filename `.DS_Store` を binary として
+スキャン対象外にする。それ以外は未知の text-like file として
+`source-read: ... is not valid UTF-8 text (fail-closed)` で赤にする。binary と判定したファイルは
+`binary files skipped: N` に集計した直後へ
 `  skipped (binary): <relative path>` と1ファイル1行で名前も表示する。Git mode の symlink は Git が
 公開する readlink text を検査する。`rglob-fallback` は symlink を follow せず、
 `symlinks skipped: N` に集計する。
+
+binary suffix の例には `.png` と `.plist` が含まれる。ただし suffix は decode 前の除外条件ではないため、
+UTF-8 XML の `.plist` は通常どおり全文を検査し、binary plist のように UTF-8 decode できないものだけを
+skip する。
+
+`BINARY_SUFFIXES` は stencil 上流の公開ポリシーであり、byte-identical copy を採用するリポが局所的に
+調整する対象ではない。未知の suffix が非 UTF-8 として赤になった場合は、ファイルを UTF-8 へ変換する、
+Git mode なら publishable corpus から untrack する、または suffix 追加の upstream PR を開く、のいずれかで
+対処する。
 
 summary は必ず `enumeration: git` または `enumeration: rglob-fallback` と、
 `denylist rules loaded : N` を表示する。raw view の hit は raw text の行番号を使い、percent/HTML decode 後に
@@ -179,18 +190,18 @@ summary は必ず `enumeration: git` または `enumeration: rglob-fallback` と
 
 ## 2026-09 改訂（#97 / #98）— 採用リポの再コピー差分
 
-`2d2d4b3` の byte-identical copy を保持している採用リポは、`v0.22.0` で配布される checker を
-再コピーし、次の caller-visible な差分を取り込む。
+`2d2d4b3` の byte-identical copy を保持している採用リポは、この変更を含む handbook release
+（この PR の merge 時に `v0.22.0` として切る）の checker を再コピーし、次の caller-visible な差分を取り込む。
 
-- text suffix または拡張子なしのファイルが UTF-8 でなければ、
-  `source-read: ... is not valid UTF-8 text (fail-closed)` で赤になる。genuinely binary な suffix は従来どおり
-  skip するが、`binary files skipped:` の直下へ相対パスを列挙する。caller 側の
-  `binary files skipped: 0` grep guard は不要になったが、残しても害はない。
+- 既知の binary suffix または exact filename `.DS_Store` 以外のファイルが UTF-8 でなければ、
+  `source-read: ... is not valid UTF-8 text (fail-closed)` で赤になる。既知の binary file は decode に
+  失敗した場合だけ skip し、`binary files skipped:` の直下へ相対パスを列挙する。caller 側の
+  `binary files skipped: 0` grep guard は追加の guard として引き続き有効である。
 - `--registry` の省略は赤になる。レジストリを持たない caller は `--no-registry` を追加する。
   `registry/modules.json` が disk 上にある状態での `--no-registry` も赤になる。
 - bare `@github.com/<slug>/<repo>` と `@github.com/<slug>` も personal-url として検出する。
   `local@github.com/...` は引き続き URL 検査ではなく e-mail denylist rule の担当とする。
-- 再コピー対象は、この変更を含む handbook release `v0.22.0`。
+- 再コピー対象は、この変更を含む handbook release（この PR の merge 時に `v0.22.0` として切る）。
 
 ## family-os / organization `.github` からの移行
 
@@ -203,8 +214,8 @@ summary は必ず `enumeration: git` または `enumeration: rglob-fallback` と
   新しく赤になった場合、検知退行ではなく bug fix の結果として対象テキストを直す。
 - 外部 `.publication-denylist` は必須。先にファイルを配置・カスタマイズせず checker だけを切り替えると、
   ゲートは意図的に赤のままになる。
-- text suffix または拡張子なしのファイルの decode failure は binary skip にせず赤にする。これは旧コピーの
-  fail-closed な挙動と一致し、template 化の途中で生じた検査姿勢の緩みを戻す差分である。
+- 既知の binary suffix または exact filename `.DS_Store` 以外の decode failure は binary skip にせず赤にする。
+  これは旧コピーの fail-closed な挙動と一致し、template 化の途中で生じた検査姿勢の緩みを戻す差分である。
 - 通常実行では `--registry` か `--no-registry` の明示が必須。レジストリを持たない移行先は CI と
   ローカルの呼び出しへ `--no-registry` を追加する。
 

--- a/templates/publication-gate/README.md
+++ b/templates/publication-gate/README.md
@@ -18,12 +18,15 @@ required status check に登録して初めて「保護済み」と扱う。
 | 個人 URL の registry allowlist | 台帳で公開対象と宣言した URL だけを個人用 URL 検査から免除すること | allowlist 検査を skip し、明示的な notice を出す |
 | 公開ラベル | 台帳の対象に公開ラベルが無い状態を残さないこと | 「ラベル欠落」検査を skip し、notice を出す |
 | SVG 状態 | README の表示と台帳の公開状態が食い違わないこと | 検査を skip し、notice を出す |
-| label whitelist の stale | 一時的な例外が台帳変更後も残らないこと | 検査を skip し、notice を出す |
+| label whitelist の stale | 一時的な例外が台帳変更後も残らないこと | whitelist が不在/空なら検査を skip して notice、1件以上なら赤 |
 
 通常検査では `--registry` か `--no-registry` のどちらかを明示する。両方を省略した場合と、両方を
 指定した場合は設定不備として赤になる。`--no-registry` を明示した場合も denylist と個人用 URL の
-検査は実行し、確認不能な4検査を黙って緑にせず、それぞれ skip notice を出す。さらに
-`<root>/registry/modules.json` が存在するのに `--no-registry` を指定した場合も赤になる。corpus の
+検査は実行し、`<root>/registry/modules.json` と非空の `.publication-label-whitelist` のどちらも無い時に限り、
+確認不能な4検査を黙って緑にせず、それぞれ skip notice を出す。`<root>/registry/modules.json` が存在する、
+または非空の `.publication-label-whitelist` がある状態で `--no-registry` を指定した場合は赤になる。
+`registry/modules.json` と非空の label whitelist だけが checker が
+知り得る on-disk signal であり、custom path の registry は caller が `--registry` で渡す責任を負う。corpus の
 アンカーは、レジストリ有りなら指定した JSON ファイル、明示的なレジストリなしなら
 `<root>/README.md` へ fallback する。カレントディレクトリ下の別 README を偶然拾って判定の起点には
 しない。レジストリなしで `<root>/README.md` も無い場合は、corpus floor を確立できないため赤になる。
@@ -33,6 +36,8 @@ required status check に登録して初めて「保護済み」と扱う。
 `<slug>.github.io` も対象になる。host の port は無視し、末尾の dot は1個だけ除く。
 `--account-slug` は前後の空白を除いた後、GitHub slug 形の
 `^[A-Za-z0-9](?:[A-Za-z0-9-]{0,37})$` に一致しなければ設定不備として赤になる。
+`@` の直前が e-mail の local part を構成しない文字（空白・括弧・`!` など）の場合は bare
+`@host/...` として URL 検査の対象になる。
 
 ## 展開手順（コピペ順）
 
@@ -96,6 +101,10 @@ NAME<TAB>REGEX
   **malformed = 赤**。
 - `.publication-denylist` 自体の不在と、コメント/空行を除く有効ルール0件はどちらも**赤**。
 
+個人用 URL 検査は e-mail 形（`local@host/...`）を意図的に URL とみなさない。したがって採用リポの
+`.publication-denylist` は e-mail ルールを**必ず**含めること（sample には `email-address` ルールを同梱。
+sample を使わず自前 denylist を書く場合も同等のルールを載せる）。
+
 denylist は検出すべき禁止リテラルを必然的に含む。そのため checker は、スキャン対象から
 既定の `<root>/.publication-denylist`、または `--denylist` で明示したファイルが root 内にある場合は
 そのファイルを**パスで**自己除外する。この path-exclusion は、拡張子 allowlist を廃止して全 regular file を
@@ -127,8 +136,9 @@ PATH<TAB>EXACT_LINE
 `PATH` と、そのファイル内で許可する `EXACT_LINE` の完全一致だけを免除する。このファイルは
 **言い訳だけを追加する** allowlist であり、新しい問題を検出するポリシーではない。したがって不在時は
 fail-open（免除なしとして継続）でよい。denylist の不存を赤にするのとは非対称だが、意図的な設計である。
-`--no-registry` を明示した場合は whitelist-staleness を判定できないため、その検査は notice 付きで
-skip する。
+`--no-registry` を明示した場合、whitelist が不在または空なら whitelist-staleness を判定できないため
+その検査は notice 付きで skip する。一方、1件以上の whitelist がある場合は staleness を検査できない
+状態を許可せず、fail-closed で赤になる。
 
 ## CLI
 
@@ -198,9 +208,12 @@ summary は必ず `enumeration: git` または `enumeration: rglob-fallback` と
   失敗した場合だけ skip し、`binary files skipped:` の直下へ相対パスを列挙する。caller 側の
   `binary files skipped: 0` grep guard は追加の guard として引き続き有効である。
 - `--registry` の省略は赤になる。レジストリを持たない caller は `--no-registry` を追加する。
-  `registry/modules.json` が disk 上にある状態での `--no-registry` も赤になる。
+  `registry/modules.json` が disk 上にある状態、または非空の `.publication-label-whitelist` がある状態での
+  `--no-registry` も赤になる。
 - bare `@github.com/<slug>/<repo>` と `@github.com/<slug>` も personal-url として検出する。
-  `local@github.com/...` は引き続き URL 検査ではなく e-mail denylist rule の担当とする。
+  個人用 URL 検査は e-mail 形（`local@host/...`）を意図的に URL とみなさないため、採用リポの
+  `.publication-denylist` は e-mail ルールを**必ず**含めること。sample には `email-address` ルールを同梱し、
+  sample を使わず自前 denylist を書く場合も同等のルールを載せる。
 - 再コピー対象は、この変更を含む handbook release（この PR の merge 時に `v0.22.0` として切る）。
 
 ## family-os / organization `.github` からの移行

--- a/templates/publication-gate/README.md
+++ b/templates/publication-gate/README.md
@@ -34,9 +34,14 @@ required status check に登録して初めて「保護済み」と扱う。
 個人用 URL は URL 候補を解析して host を正規化してから照合する。`github.com/<slug>` に加え、
 `github.com:443/<slug>`、`github.com./<slug>`、`gist.github.com/<slug>`、
 `<slug>.github.io` も対象になる。host の port は無視し、末尾の dot は1個だけ除く。
+URL 候補の path 内に `github.com/<slug>`・`gist.github.com/<slug>`・`<slug>.github.io` が現れる場合
+（`foo.bar/github.com/<slug>/<repo>`、`?u=github.com/<slug>/...`、`github.com\/<slug>\/...`）も
+personal-url として赤にする。`https://example.org/docs/github.com/<slug>/<repo>` のような無関係ホストの
+path に personal URL が現れる場合や、`<slug>.github.io` という segment があるだけでも赤になる fail-closed
+の設計であり、該当テキストを修正するか registry allowlist へ追加して対処する。
 `--account-slug` は前後の空白を除いた後、GitHub slug 形の
 `^[A-Za-z0-9](?:[A-Za-z0-9-]{0,37})$` に一致しなければ設定不備として赤になる。
-`@` の直前が e-mail の local part を構成しない文字（空白・括弧・`!` など）の場合は bare
+`@` の直前が英数字または `_` の word character でない場合は bare
 `@host/...` として URL 検査の対象になる。
 
 ## 展開手順（コピペ順）
@@ -173,17 +178,18 @@ __pycache__
 
 列挙された regular file は suffix やファイル名で選別せず、`.env.local`、`.cs`、`.csproj`、`.ipynb`、
 `.txt`、`.csv`、`LICENSE`、`Dockerfile`、拡張子なしもすべて先に UTF-8 decode を試す。decode
-できなかった場合だけ、明示した既知の binary suffix または exact filename `.DS_Store` を binary として
-スキャン対象外にする。それ以外は未知の text-like file として
+できなかった場合だけ、明示した既知の binary suffix、exact filename `.DS_Store`、または先頭が
+`bplist00` の binary plist signature を持つファイルを binary としてスキャン対象外にする。それ以外は未知の
+text-like file として
 `source-read: ... is not valid UTF-8 text (fail-closed)` で赤にする。binary と判定したファイルは
 `binary files skipped: N` に集計した直後へ
 `  skipped (binary): <relative path>` と1ファイル1行で名前も表示する。Git mode の symlink は Git が
 公開する readlink text を検査する。`rglob-fallback` は symlink を follow せず、
 `symlinks skipped: N` に集計する。
 
-binary suffix の例には `.png` と `.plist` が含まれる。ただし suffix は decode 前の除外条件ではないため、
-UTF-8 XML の `.plist` は通常どおり全文を検査し、binary plist のように UTF-8 decode できないものだけを
-skip する。
+binary suffix の例には `.png` と `.icns` が含まれる。`.plist` は binary set に入れず、UTF-8 XML plist は
+通常どおり全文を検査し、UTF-16 XML plist は source-read として赤にする。binary plist は suffix にかかわらず
+`bplist00` signature により skip する。鍵・証明書コンテナは意図的に binary set に入れない＝赤。
 
 `BINARY_SUFFIXES` は stencil 上流の公開ポリシーであり、byte-identical copy を採用するリポが局所的に
 調整する対象ではない。未知の suffix が非 UTF-8 として赤になった場合は、ファイルを UTF-8 へ変換する、
@@ -211,9 +217,15 @@ summary は必ず `enumeration: git` または `enumeration: rglob-fallback` と
   `registry/modules.json` が disk 上にある状態、または非空の `.publication-label-whitelist` がある状態での
   `--no-registry` も赤になる。
 - bare `@github.com/<slug>/<repo>` と `@github.com/<slug>` も personal-url として検出する。
-  個人用 URL 検査は e-mail 形（`local@host/...`）を意図的に URL とみなさないため、採用リポの
+  `+@github.com/<slug>/<repo>` と `%@github.com/<slug>/<repo>` も検出する一方、`@` の直前が英数字または
+  `_` の word character の e-mail 形は意図的に URL とみなさないため、採用リポの
   `.publication-denylist` は e-mail ルールを**必ず**含めること。sample には `email-address` ルールを同梱し、
   sample を使わず自前 denylist を書く場合も同等のルールを載せる。
+- URL 候補の path 内に `github.com/<slug>`・`gist.github.com/<slug>`・`<slug>.github.io` が現れる場合
+  （`foo.bar/github.com/<slug>/<repo>`、`?u=github.com/<slug>/...`、`github.com\/<slug>\/...`）も
+  personal-url として赤にする。`https://example.org/docs/github.com/<slug>/<repo>` のような無関係ホストの
+  path に personal URL が現れる場合や、`<slug>.github.io` segment があるだけでも赤になる fail-closed のため、
+  該当テキストを修正するか registry allowlist へ追加して対処する。
 - 再コピー対象は、この変更を含む handbook release（この PR の merge 時に `v0.22.0` として切る）。
 
 ## family-os / organization `.github` からの移行

--- a/templates/publication-gate/README.md
+++ b/templates/publication-gate/README.md
@@ -38,7 +38,8 @@ URL 候補の path 内に `github.com/<slug>`・`gist.github.com/<slug>`・`<slu
 （`foo.bar/github.com/<slug>/<repo>`、`?u=github.com/<slug>/...`、`github.com\/<slug>\/...`）も
 personal-url として赤にする。`https://example.org/docs/github.com/<slug>/<repo>` のような無関係ホストの
 path に personal URL が現れる場合や、`<slug>.github.io` という segment があるだけでも赤になる fail-closed
-の設計であり、該当テキストを修正するか registry allowlist へ追加して対処する。
+の設計であり、nested URL は次の `?`・`#`・`=`・`&` query/fragment field 境界までを照合する。該当テキストを
+修正するか registry allowlist へ追加して対処する。
 `--account-slug` は前後の空白を除いた後、GitHub slug 形の
 `^[A-Za-z0-9](?:[A-Za-z0-9-]{0,37})$` に一致しなければ設定不備として赤になる。
 `@` の直前が英数字または `_` の word character でない場合は bare
@@ -179,7 +180,7 @@ __pycache__
 列挙された regular file は suffix やファイル名で選別せず、`.env.local`、`.cs`、`.csproj`、`.ipynb`、
 `.txt`、`.csv`、`LICENSE`、`Dockerfile`、拡張子なしもすべて先に UTF-8 decode を試す。decode
 できなかった場合だけ、明示した既知の binary suffix、exact filename `.DS_Store`、または先頭が
-`bplist00` の binary plist signature を持つファイルを binary としてスキャン対象外にする。それ以外は未知の
+`bplist00` で suffix が `.plist` / `.bplist` の binary plist を binary としてスキャン対象外にする。それ以外は未知の
 text-like file として
 `source-read: ... is not valid UTF-8 text (fail-closed)` で赤にする。binary と判定したファイルは
 `binary files skipped: N` に集計した直後へ
@@ -188,8 +189,8 @@ text-like file として
 `symlinks skipped: N` に集計する。
 
 binary suffix の例には `.png` と `.icns` が含まれる。`.plist` は binary set に入れず、UTF-8 XML plist は
-通常どおり全文を検査し、UTF-16 XML plist は source-read として赤にする。binary plist は suffix にかかわらず
-`bplist00` signature により skip する。鍵・証明書コンテナは意図的に binary set に入れない＝赤。
+通常どおり全文を検査し、UTF-16 XML plist は source-read として赤にする。binary plist は `.plist` / `.bplist`
+の `bplist00` signature により skip する。鍵・証明書コンテナは意図的に binary set に入れない＝赤。
 
 `BINARY_SUFFIXES` は stencil 上流の公開ポリシーであり、byte-identical copy を採用するリポが局所的に
 調整する対象ではない。未知の suffix が非 UTF-8 として赤になった場合は、ファイルを UTF-8 へ変換する、
@@ -221,11 +222,7 @@ summary は必ず `enumeration: git` または `enumeration: rglob-fallback` と
   `_` の word character の e-mail 形は意図的に URL とみなさないため、採用リポの
   `.publication-denylist` は e-mail ルールを**必ず**含めること。sample には `email-address` ルールを同梱し、
   sample を使わず自前 denylist を書く場合も同等のルールを載せる。
-- URL 候補の path 内に `github.com/<slug>`・`gist.github.com/<slug>`・`<slug>.github.io` が現れる場合
-  （`foo.bar/github.com/<slug>/<repo>`、`?u=github.com/<slug>/...`、`github.com\/<slug>\/...`）も
-  personal-url として赤にする。`https://example.org/docs/github.com/<slug>/<repo>` のような無関係ホストの
-  path に personal URL が現れる場合や、`<slug>.github.io` segment があるだけでも赤になる fail-closed のため、
-  該当テキストを修正するか registry allowlist へ追加して対処する。
+- nested host を含む URL 候補の personal-url 検査は、上記「個人用 URL」節を参照する。
 - 再コピー対象は、この変更を含む handbook release（この PR の merge 時に `v0.22.0` として切る）。
 
 ## family-os / organization `.github` からの移行

--- a/templates/publication-gate/check_publication_gate.py
+++ b/templates/publication-gate/check_publication_gate.py
@@ -374,26 +374,31 @@ def _nested_personal_urls(candidate, account_slug):
 
     def marker_positions(marker):
         if len(folded) != len(candidate):
-            return (match.start() for match in re.finditer(re.escape(marker), candidate, re.IGNORECASE))
+            return tuple(
+                match.start()
+                for match in re.finditer(re.escape(marker), candidate, re.IGNORECASE)
+            )
         positions = []
         index = folded.find(marker)
         while index >= 0:
             positions.append(index)
             index = folded.find(marker, index + 1)
-        return positions
+        return tuple(positions)
 
-    for marker in ("github.com", "www.github.com", "gist.github.com"):
-        for index in marker_positions(marker):
-            if index > 0 and candidate[index - 1] in split_characters:
-                starts.add(index)
-    github_io_positions = iter(marker_positions(".github.io"))
-    next_github_io = next(github_io_positions, None)
+    marker_indexes = sorted(
+        {
+            index
+            for marker in ("github.com", ".github.io")
+            for index in marker_positions(marker)
+        }
+    )
+    marker_indexes = iter(marker_indexes)
+    next_marker = next(marker_indexes, None)
     previous_split = -1
     for index, character in enumerate(candidate):
-        while next_github_io == index:
-            if previous_split >= 0:
-                starts.add(previous_split + 1)
-            next_github_io = next(github_io_positions, None)
+        while next_marker == index:
+            starts.add(previous_split + 1 if previous_split >= 0 else 0)
+            next_marker = next(marker_indexes, None)
         if character in split_characters:
             previous_split = index
     repo_name = _personal_url(candidate, account_slug)
@@ -882,6 +887,38 @@ def selftest_policy_parsers():
 
 
 def selftest_scanners():
+    def assert_single_personal_url(source, expected_fragment, message):
+        failures = []
+        _selftest_check(
+            check_personal_urls(
+                {"README.md": source}, "neutral-owner", None, failures
+            )
+            == 1
+            and len(failures) == 1
+            and expected_fragment in failures[0],
+            message,
+        )
+
+    def reference_nested_personal_urls(candidate, account_slug):
+        candidate = candidate.replace("\\", "/")
+        starts = {0}
+        starts.update(
+            index + 1
+            for index, character in enumerate(candidate)
+            if character in "/?#=&" and index + 1 < len(candidate)
+        )
+        field_end = -1
+        matches = set()
+        for start in sorted(starts):
+            if field_end < start:
+                field_end = start
+                while field_end < len(candidate) and candidate[field_end] not in "?#=&":
+                    field_end += 1
+            repo_name = _personal_url(candidate[start:field_end], account_slug)
+            if repo_name is not False:
+                matches.add(repo_name)
+        return matches
+
     rules = (("private marker", re.compile("private" + "[- ]marker", re.IGNORECASE)),)
     failures = []
     documents = {"README.md": "private%2Dmarker\n"}
@@ -1234,6 +1271,89 @@ def selftest_scanners():
         ],
         "nested query repository name excludes later fields",
     )
+    nested_userinfo_cases = (
+        (
+            "https://example.org/?u=user:pass@github." "com/neutral-owner/repo",
+            "neutral-owner/repo",
+            "nested query userinfo repository",
+        ),
+        (
+            "https://example.org/?u=www.gist.github." "com/neutral-owner/id",
+            "personal account profile",
+            "nested query gist profile with www prefix",
+        ),
+        (
+            "https://example.org/?u=User:Pass@GitHub." "com/neutral-owner/repo",
+            "neutral-owner/repo",
+            "nested query mixed-case userinfo repository",
+        ),
+        (
+            "https://example.org/?u=@github." "com/neutral-owner/bareat",
+            "neutral-owner/bareat",
+            "nested query bare-at repository",
+        ),
+        (
+            "https://example.org/?u=user@github." "com/neutral-owner/userinfo",
+            "neutral-owner/userinfo",
+            "nested query single-userinfo repository",
+        ),
+        (
+            "https://example.org/#a&user@github." "com/neutral-owner/frag",
+            "neutral-owner/frag",
+            "fragment ampersand userinfo repository",
+        ),
+    )
+    for source, expected_fragment, message in nested_userinfo_cases:
+        assert_single_personal_url(source, expected_fragment, message)
+    nested_notgithub_failures = []
+    _selftest_check(
+        check_personal_urls(
+            {"README.md": "https://example.org/?u=notgithub." "com/neutral-owner/repo"},
+            "neutral-owner",
+            None,
+            nested_notgithub_failures,
+        )
+        == 0
+        and not nested_notgithub_failures,
+        "nested query notgithub control",
+    )
+    urlsplit_leading_at = urllib.parse.urlsplit(
+        "//@github." "com/neutral-owner/bareat"
+    )
+    _selftest_check(
+        urlsplit_leading_at.hostname == "github.com"
+        and urlsplit_leading_at.path == "/neutral-owner/bareat",
+        "urlsplit treats leading at-sign as userinfo without parser workaround",
+    )
+    nested_reference_cases = (
+        _fixture_personal_url("neutral-owner", "repo"),
+        "github." "com/neutral-owner/repo",
+        "@github." "com/neutral-owner/bareat",
+        "user@github." "com/neutral-owner/userinfo",
+        "user:pass@github." "com/neutral-owner/creds",
+        "User:Pass@GitHub." "com/neutral-owner/case",
+        "www.github." "com/neutral-owner/wwwrepo",
+        "gist.github." "com/neutral-owner/gist-id",
+        "www.gist.github." "com/neutral-owner/gist-id",
+        "github." "com./neutral-owner/trailing-dot",
+        "github." "com:443/neutral-owner/port",
+        "https://example.org/?u=github." "com/neutral-owner/query",
+        "https://example.org/?u=user@github." "com/neutral-owner/query-user",
+        "https://example.org/#github." "com/neutral-owner/frag",
+        "https://example.org/#a&user@github." "com/neutral-owner/frag",
+        "https://github." "com\\/neutral-owner\\/slashes",
+        "github." "com\\/neutral-owner\\/slashes",
+        "https://example.org/?u=%40github." "com/neutral-owner/encoded-at",
+        "https://example.org/?u=neutral-owner.github." "io/page",
+        "https://example.org/?u=notgithub." "com/neutral-owner/nope",
+        "https://example.org/?u=github." "com/neutral-owner/one&b=github." "com/neutral-owner/two",
+    )
+    for candidate in nested_reference_cases:
+        _selftest_check(
+            set(_nested_personal_urls(candidate, "neutral-owner"))
+            == reference_nested_personal_urls(candidate, "neutral-owner"),
+            "nested boundary walk matches reference: %s" % candidate,
+        )
     two_repo_registry = _fixture_registry()
     two_repo_registry["modules"].extend(
         (

--- a/templates/publication-gate/check_publication_gate.py
+++ b/templates/publication-gate/check_publication_gate.py
@@ -35,7 +35,7 @@ BINARY_SUFFIXES = frozenset(
     (
         ".png", ".jpg", ".jpeg", ".gif", ".webp", ".ico", ".icns", ".bmp", ".tif",
         ".tiff", ".avif", ".heic", ".heif", ".jfif", ".psd", ".ai", ".eps", ".sketch",
-        ".fig", ".glb", ".gltf", ".svgz", ".woff", ".woff2", ".ttf", ".ttc", ".otf",
+        ".fig", ".glb", ".svgz", ".woff", ".woff2", ".ttf", ".ttc", ".otf",
         ".eot", ".zip", ".gz", ".tgz", ".tar", ".bz2", ".xz", ".zst", ".lz4", ".7z",
         ".rar", ".iso", ".img", ".jar", ".war", ".whl", ".egg", ".gem", ".nupkg",
         ".deb", ".rpm", ".dmg", ".pkg", ".apk", ".ipa", ".pdf", ".doc", ".docx",
@@ -290,7 +290,10 @@ def read_sources(root, failures, excluded_policy_path):
                 if (
                     path.suffix.lower() in BINARY_SUFFIXES
                     or path.name == ".DS_Store"
-                    or raw.startswith(b"bplist00")
+                    or (
+                        raw.startswith(b"bplist00")
+                        and path.suffix.lower() in (".plist", ".bplist")
+                    )
                 ):
                     binary_skipped += 1
                     binary_skipped_paths.append(relative)
@@ -350,22 +353,63 @@ def _personal_url(candidate, account_slug):
 def _nested_personal_urls(candidate, account_slug):
     """Yield every distinct personal URL found at a nested URL boundary."""
     candidate = candidate.replace("\\", "/")
+    folded = candidate.casefold()
+    # Every _personal_url host rule requires github.com or github.io, including gist.
+    if "github.com" not in folded and "github.io" not in folded:
+        return
     reported = set()
-    split_characters = "/?#=&\\"
-    for index in range(-1, len(candidate)):
-        if index >= 0 and candidate[index] not in split_characters:
-            continue
-        repo_name = _personal_url(candidate[index + 1 :], account_slug)
-        if repo_name is False:
-            continue
-        folded = (
+    split_characters = "/?#=&"
+    starts = set()
+
+    def unseen(repo_name):
+        name = (
             account_slug
             if repo_name is None
             else account_slug + "/" + repo_name
         ).casefold()
-        if folded in reported:
+        if name in reported:
+            return False
+        reported.add(name)
+        return True
+
+    def marker_positions(marker):
+        if len(folded) != len(candidate):
+            return (match.start() for match in re.finditer(re.escape(marker), candidate, re.IGNORECASE))
+        positions = []
+        index = folded.find(marker)
+        while index >= 0:
+            positions.append(index)
+            index = folded.find(marker, index + 1)
+        return positions
+
+    for marker in ("github.com", "www.github.com", "gist.github.com"):
+        for index in marker_positions(marker):
+            if index > 0 and candidate[index - 1] in split_characters:
+                starts.add(index)
+    github_io_positions = iter(marker_positions(".github.io"))
+    next_github_io = next(github_io_positions, None)
+    previous_split = -1
+    for index, character in enumerate(candidate):
+        while next_github_io == index:
+            if previous_split >= 0:
+                starts.add(previous_split + 1)
+            next_github_io = next(github_io_positions, None)
+        if character in split_characters:
+            previous_split = index
+    repo_name = _personal_url(candidate, account_slug)
+    if repo_name is not False and unseen(repo_name):
+        yield repo_name
+    field_end = 0
+    for start in range(len(candidate)):
+        if start not in starts:
             continue
-        reported.add(folded)
+        if field_end < start:
+            field_end = start
+            while field_end < len(candidate) and candidate[field_end] not in "?#=&":
+                field_end += 1
+        repo_name = _personal_url(candidate[start:field_end], account_slug)
+        if repo_name is False or not unseen(repo_name):
+            continue
         yield repo_name
 
 
@@ -904,6 +948,27 @@ def selftest_scanners():
         in userinfo_failures[0],
         "userinfo personal URL candidate",
     )
+    userinfo_field_failures = []
+    _selftest_check(
+        check_personal_urls(
+            {
+                "README.md": "See "
+                + _fixture_userinfo_personal_url(
+                    "neutral-owner", "private", "viewer=token"
+                )
+            },
+            "neutral-owner",
+            None,
+            userinfo_field_failures,
+        )
+        == 1
+        and userinfo_field_failures
+        == [
+            "personal-url: README.md:1 references personal account repository "
+            "neutral-owner/private"
+        ],
+        "outer userinfo URL is not cut at an equals sign",
+    )
     clean_userinfo_failures = []
     _selftest_check(
         check_personal_urls(
@@ -1139,6 +1204,92 @@ def selftest_scanners():
         == 0
         and not nested_query_control_failures,
         "nested query unrelated-host control",
+    )
+    nested_profile_failures = []
+    _selftest_check(
+        check_personal_urls(
+            {"README.md": "https://example.org/?u=github." "com/neutral-owner&x=safe"},
+            "neutral-owner",
+            None,
+            nested_profile_failures,
+        )
+        == 1
+        and len(nested_profile_failures) == 1
+        and "personal account profile" in nested_profile_failures[0],
+        "nested query profile stops at the next field",
+    )
+    nested_repo_failures = []
+    _selftest_check(
+        check_personal_urls(
+            {"README.md": "https://example.org/?u=github." "com/neutral-owner/repo&x=1"},
+            "neutral-owner",
+            None,
+            nested_repo_failures,
+        )
+        == 1
+        and nested_repo_failures
+        == [
+            "personal-url: README.md:1 references personal account repository "
+            "neutral-owner/repo"
+        ],
+        "nested query repository name excludes later fields",
+    )
+    two_repo_registry = _fixture_registry()
+    two_repo_registry["modules"].extend(
+        (
+            {"name": "One", "repo": "neutral-owner/one", "status": "published"},
+            {"name": "Two", "repo": "neutral-owner/two", "status": "published"},
+        )
+    )
+    nested_allowlisted_failures = []
+    _selftest_check(
+        check_personal_urls(
+            {
+                "README.md": (
+                    "https://example.org/?a=github." "com/neutral-owner/one"
+                    "&b=github." "com/neutral-owner/two"
+                )
+            },
+            "neutral-owner",
+            two_repo_registry,
+            nested_allowlisted_failures,
+        )
+        == 2
+        and not nested_allowlisted_failures,
+        "nested allowlisted repositories do not absorb later fields",
+    )
+    large_nested_token = "a/=" * (200000 // 3)
+    large_clean_failures = []
+    _selftest_check(
+        check_personal_urls(
+            {"README.md": "https://example.org/" + large_nested_token},
+            "neutral-owner",
+            None,
+            large_clean_failures,
+        )
+        == 0
+        and not large_clean_failures,
+        "large separator-dense token without a GitHub marker",
+    )
+    midpoint = len(large_nested_token) // 2
+    large_nested_failures = []
+    _selftest_check(
+        check_personal_urls(
+            {
+                "README.md": (
+                    "https://example.org/"
+                    + large_nested_token[:midpoint]
+                    + "github." "com/neutral-owner/x"
+                    + large_nested_token[midpoint:]
+                )
+            },
+            "neutral-owner",
+            None,
+            large_nested_failures,
+        )
+        == 1
+        and len(large_nested_failures) == 1,
+        "large separator-dense token finds one nested GitHub URL",
     )
 
     normalized_failures = []
@@ -1403,6 +1554,20 @@ def selftest_end_to_end():
     with tempfile.TemporaryDirectory() as temporary:
         root = Path(temporary)
         _materialize_fixture(root)
+        (root / "scene.gltf").write_bytes(b"{\"note\": \"acme-" b"secret\"}\xff")
+        status, output = _capture_main(
+            ["--root", str(root), "--account-slug", "neutral-owner", "--no-registry"]
+        )
+        _selftest_check(
+            status == 1
+            and "source-read: scene.gltf is not valid UTF-8 text (fail-closed)" in output
+            and "binary files skipped: 0" in output,
+            "non-UTF-8 glTF JSON fails closed as source text: %r" % output,
+        )
+
+    with tempfile.TemporaryDirectory() as temporary:
+        root = Path(temporary)
+        _materialize_fixture(root)
         (root / "id_rsa.key").write_bytes(b"\x30\x82\xff\x00")
         status, output = _capture_main(
             ["--root", str(root), "--account-slug", "neutral-owner", "--no-registry"]
@@ -1431,7 +1596,7 @@ def selftest_end_to_end():
     with tempfile.TemporaryDirectory() as temporary:
         root = Path(temporary)
         _materialize_fixture(root)
-        (root / "fixture.plist").write_bytes(
+        (root / "Info.plist").write_bytes(
             plistlib.dumps({"note": "x"}, fmt=plistlib.FMT_BINARY)
         )
         status, output = _capture_main(
@@ -1440,24 +1605,22 @@ def selftest_end_to_end():
         _selftest_check(
             status == 0
             and "binary files skipped: 1" in output
-            and "  skipped (binary): fixture.plist" in output,
+            and "  skipped (binary): Info.plist" in output,
             "binary plist is skipped and listed: %r" % output,
         )
 
     with tempfile.TemporaryDirectory() as temporary:
         root = Path(temporary)
         _materialize_fixture(root)
-        (root / "fixture.xml").write_bytes(
-            plistlib.dumps({"note": "x"}, fmt=plistlib.FMT_BINARY)
-        )
+        (root / "notes.md").write_bytes(b"bplist00acme-" b"secret\xff")
         status, output = _capture_main(
             ["--root", str(root), "--account-slug", "neutral-owner", "--no-registry"]
         )
         _selftest_check(
-            status == 0
-            and "binary files skipped: 1" in output
-            and "  skipped (binary): fixture.xml" in output,
-            "binary plist signature skips any suffix: %r" % output,
+            status == 1
+            and "source-read: notes.md is not valid UTF-8 text (fail-closed)" in output
+            and "binary files skipped: 0" in output,
+            "binary plist signature requires a plist suffix: %r" % output,
         )
 
     with tempfile.TemporaryDirectory() as temporary:

--- a/templates/publication-gate/check_publication_gate.py
+++ b/templates/publication-gate/check_publication_gate.py
@@ -16,6 +16,7 @@ import io
 import json
 import os
 from pathlib import Path
+import plistlib
 import re
 import shutil
 import stat
@@ -31,24 +32,24 @@ EXCLUDED_DIRS = frozenset(
 DENYLIST_NAME = ".publication-denylist"
 WHITELIST_NAME = ".publication-label-whitelist"
 ACCOUNT_SLUG = re.compile(r"^[A-Za-z0-9](?:[A-Za-z0-9-]{0,37})$")
-TEXT_SUFFIXES = frozenset(
+BINARY_SUFFIXES = frozenset(
     (
-        ".md", ".markdown", ".mdx", ".txt", ".text", ".rst", ".adoc", ".svg",
-        ".json", ".jsonc", ".json5", ".yml", ".yaml", ".toml", ".ini", ".cfg",
-        ".conf", ".env", ".xml", ".html", ".htm", ".css", ".scss", ".less",
-        ".js", ".mjs", ".cjs", ".ts", ".tsx", ".jsx", ".py", ".pyi", ".sh",
-        ".bash", ".zsh", ".fish", ".rb", ".go", ".rs", ".java", ".kt", ".kts",
-        ".swift", ".c", ".h", ".cc", ".cpp", ".hpp", ".m", ".mm", ".php",
-        ".pl", ".lua", ".sql", ".csv", ".tsv", ".tex", ".bib", ".ps1", ".bat",
-        ".cmd", ".properties", ".lock", ".mk", ".cmake", ".gradle", ".plist",
-        ".graphql", ".proto", ".tf", ".hcl", ".vue", ".svelte", ".astro", ".njk",
-        ".hbs", ".ejs", ".pug", ".diff", ".patch", ".log", ".cff", ".bzl", ".nix",
-        ".dart", ".scala", ".clj", ".ex", ".exs", ".erl", ".hs", ".ml", ".r",
-        ".jl",
+        ".png", ".jpg", ".jpeg", ".gif", ".webp", ".ico", ".bmp", ".tif",
+        ".tiff", ".avif", ".heic", ".heif", ".psd", ".svgz", ".woff", ".woff2",
+        ".ttf", ".otf", ".eot", ".zip", ".gz", ".tgz", ".tar", ".bz2", ".xz",
+        ".zst", ".7z", ".rar", ".jar", ".war", ".whl", ".egg", ".gem", ".nupkg",
+        ".deb", ".rpm", ".dmg", ".pkg", ".apk", ".ipa", ".pdf", ".doc", ".docx",
+        ".xls", ".xlsx", ".ppt", ".pptx", ".key", ".numbers", ".pages", ".odt",
+        ".ods", ".odp", ".mp3", ".mp4", ".m4a", ".m4v", ".mov", ".avi", ".mkv",
+        ".webm", ".wav", ".flac", ".ogg", ".oga", ".ogv", ".aac", ".aif", ".aiff",
+        ".so", ".dylib", ".dll", ".exe", ".o", ".a", ".lib", ".obj", ".class",
+        ".pyc", ".pyd", ".wasm", ".bin", ".dat", ".db", ".sqlite", ".sqlite3",
+        ".pak", ".bundle", ".mo", ".pb", ".onnx", ".npy", ".npz", ".parquet",
+        ".arrow", ".pickle", ".pkl", ".h5", ".hdf5", ".plist",
     )
 )
 URL_CANDIDATE = re.compile(
-    r"(?<![A-Za-z0-9._-])(?<![A-Za-z0-9._%+-]@)"
+    r"(?<![A-Za-z0-9._-])(?<![A-Za-z0-9_%+]@)"
     r"(?:https?://(?:[A-Za-z0-9._~!$&'()*+,;=:%-]+@)?)?"
     r"(?:[A-Za-z0-9-]+\.)+[A-Za-z0-9-]+\.?(?::[0-9]+)?"
     r"(?:/[^\s<>'\"`()\[\]{}]*)?",
@@ -284,13 +285,13 @@ def read_sources(root, failures, excluded_policy_path):
             try:
                 documents[relative] = path.read_bytes().decode("utf-8")
             except UnicodeDecodeError:
-                if path.suffix.lower() in TEXT_SUFFIXES or path.suffix == "":
+                if path.suffix.lower() in BINARY_SUFFIXES or path.name == ".DS_Store":
+                    binary_skipped += 1
+                    binary_skipped_paths.append(relative)
+                else:
                     failures.append(
                         "source-read: %s is not valid UTF-8 text (fail-closed)" % relative
                     )
-                else:
-                    binary_skipped += 1
-                    binary_skipped_paths.append(relative)
         except OSError as exc:
             failures.append("source-read: %s could not be read: %s" % (relative, exc))
     return documents, enumeration_mode, binary_skipped, symlinks_skipped, binary_skipped_paths
@@ -339,6 +340,19 @@ def _personal_url(candidate, account_slug):
     return False
 
 
+def _nested_personal_url(candidate, account_slug):
+    repo_name = _personal_url(candidate, account_slug)
+    if repo_name is not False:
+        return repo_name
+    for index, character in enumerate(candidate):
+        if character != "/":
+            continue
+        repo_name = _personal_url(candidate[index + 1 :], account_slug)
+        if repo_name is not False:
+            return repo_name
+    return False
+
+
 def registry_allowlist(registry):
     repos = {module["repo"] for module in registry["modules"]}
     repos.update(entry["repo"] for entry in registry.get("retired_repos", []))
@@ -354,7 +368,7 @@ def check_personal_urls(documents, account_slug, registry, failures):
         reported = set()
         for view_index, view in enumerate(scan_views(text)):
             for match in URL_CANDIDATE.finditer(view):
-                repo_name = _personal_url(match.group(0), account_slug)
+                repo_name = _nested_personal_url(match.group(0), account_slug)
                 if repo_name is False:
                     continue
                 number = line_number(view, match.start())
@@ -533,10 +547,10 @@ def partition_documents(documents):
 
 
 SKIP_NOTICES = (
-    "notice: registry allowlist check skipped (--registry not provided)",
-    "notice: missing-label check skipped (--registry not provided)",
-    "notice: SVG-state check skipped (--registry not provided)",
-    "notice: whitelist-staleness check skipped (--registry not provided)",
+    "notice: registry allowlist check skipped (--no-registry declared)",
+    "notice: missing-label check skipped (--no-registry declared)",
+    "notice: SVG-state check skipped (--no-registry declared)",
+    "notice: whitelist-staleness check skipped (--no-registry declared)",
 )
 
 
@@ -564,6 +578,7 @@ def run_gate(
     binary_skipped_paths = []
     symlinks_skipped = 0
     policy_path = denylist_path(root, denylist_argument)
+    conventional_registry_exists = (root / "registry" / "modules.json").is_file()
 
     normalized_slug = account_slug.strip() if account_slug is not None else ""
     if not normalized_slug:
@@ -595,7 +610,7 @@ def run_gate(
     if (
         no_registry
         and registry_argument is None
-        and (root / "registry" / "modules.json").is_file()
+        and conventional_registry_exists
     ):
         failures.append(
             "gate-error: registry/modules.json exists under --root but --no-registry was passed "
@@ -658,7 +673,7 @@ def run_gate(
     print("module links checked : %d" % root_links)
     print("SVG names checked    : %d" % svg_names)
     print("label whitelist      : %d" % len(whitelist))
-    if no_registry and registry_argument is None:
+    if no_registry and registry_argument is None and not conventional_registry_exists:
         for notice in SKIP_NOTICES:
             print(notice)
 
@@ -921,6 +936,82 @@ def selftest_scanners():
         and not email_context_failures,
         "email-context personal URL remains denylist territory",
     )
+    dash_at_failures = []
+    _selftest_check(
+        check_personal_urls(
+            {"README.md": "-@" + _fixture_personal_url(
+                "neutral-owner", "private-repo"
+            )[len("https://") :]},
+            "neutral-owner",
+            None,
+            dash_at_failures,
+        )
+        == 1
+        and "neutral-owner/private-repo" in dash_at_failures[0],
+        "dash-at personal repository URL",
+    )
+    encoded_at_failures = []
+    encoded_at = _fixture_personal_url(
+        "neutral-owner", "private-repo"
+    ).replace("https://", "%40", 1)
+    _selftest_check(
+        check_personal_urls(
+            {"README.md": encoded_at},
+            "neutral-owner",
+            None,
+            encoded_at_failures,
+        )
+        == 1
+        and "(decoded view)" in encoded_at_failures[0],
+        "percent-encoded-at personal repository URL",
+    )
+
+    nested_cases = (
+        (
+            "see @foo.bar/" + _fixture_personal_url(
+                "neutral-owner", "private-repo"
+            )[len("https://") :],
+            "neutral-owner/private-repo",
+        ),
+        (
+            "foo.bar/" + _fixture_personal_url(
+                "neutral-owner", "private-repo"
+            )[len("https://") :],
+            "neutral-owner/private-repo",
+        ),
+        (
+            "@x.io/"
+            + _fixture_personal_url("neutral-owner", "abc")
+            .replace("https://", "", 1)
+            .replace("github.", "gist.github.", 1),
+            "personal account profile",
+        ),
+    )
+    for source, expected in nested_cases:
+        nested_failures = []
+        _selftest_check(
+            check_personal_urls(
+                {"README.md": source},
+                "neutral-owner",
+                None,
+                nested_failures,
+            )
+            == 1
+            and expected in nested_failures[0],
+            "nested personal URL suffix: %s" % source,
+        )
+    unrelated_nested_failures = []
+    _selftest_check(
+        check_personal_urls(
+            {"README.md": "https://example.org/docs/neutral-owner/notes"},
+            "neutral-owner",
+            None,
+            unrelated_nested_failures,
+        )
+        == 0
+        and not unrelated_nested_failures,
+        "nested personal URL unrelated-host control",
+    )
 
     normalized_failures = []
     normalized_documents = {
@@ -1124,6 +1215,95 @@ def selftest_end_to_end():
 
     with tempfile.TemporaryDirectory() as temporary:
         root = Path(temporary)
+        _materialize_fixture(root)
+        text_like_paths = (
+            "Program.cs",
+            "Example.csproj",
+            "notebook.ipynb",
+            ".env.local",
+            "notes.txt",
+            "table.csv",
+        )
+        for relative in text_like_paths:
+            (root / relative).write_bytes(
+                ("acme-" "secret").encode("utf-8") + b"\xff\n"
+            )
+        status, output = _capture_main(
+            ["--root", str(root), "--account-slug", "neutral-owner", "--no-registry"]
+        )
+        _selftest_check(
+            status == 1
+            and all(
+                "source-read: %s is not valid UTF-8 text (fail-closed)" % relative
+                in output
+                for relative in text_like_paths
+            )
+            and "binary files skipped: 0" in output,
+            "non-UTF-8 files use the explicit binary allowlist: %r" % output,
+        )
+
+    with tempfile.TemporaryDirectory() as temporary:
+        root = Path(temporary)
+        _materialize_fixture(root)
+        (root / "logo.png").write_bytes(b"\xff\xfe\x00")
+        status, output = _capture_main(
+            ["--root", str(root), "--account-slug", "neutral-owner", "--no-registry"]
+        )
+        _selftest_check(
+            status == 0
+            and "binary files skipped: 1" in output
+            and "  skipped (binary): logo.png" in output,
+            "non-UTF-8 PNG is skipped and listed: %r" % output,
+        )
+
+    with tempfile.TemporaryDirectory() as temporary:
+        root = Path(temporary)
+        _materialize_fixture(root)
+        (root / "fixture.plist").write_bytes(
+            plistlib.dumps({"note": "x"}, fmt=plistlib.FMT_BINARY)
+        )
+        status, output = _capture_main(
+            ["--root", str(root), "--account-slug", "neutral-owner", "--no-registry"]
+        )
+        _selftest_check(
+            status == 0
+            and "binary files skipped: 1" in output
+            and "  skipped (binary): fixture.plist" in output,
+            "binary plist is skipped and listed: %r" % output,
+        )
+
+    with tempfile.TemporaryDirectory() as temporary:
+        root = Path(temporary)
+        _materialize_fixture(root)
+        (root / ".DS_Store").write_bytes(b"\xff\xfe\x00")
+        status, output = _capture_main(
+            ["--root", str(root), "--account-slug", "neutral-owner", "--no-registry"]
+        )
+        _selftest_check(
+            status == 0
+            and "binary files skipped: 1" in output
+            and "  skipped (binary): .DS_Store" in output,
+            "exact .DS_Store filename is skipped and listed: %r" % output,
+        )
+
+    with tempfile.TemporaryDirectory() as temporary:
+        root = Path(temporary)
+        _materialize_fixture(root)
+        (root / "fixture.plist").write_bytes(
+            plistlib.dumps({"note": "acme-" "secret"}, fmt=plistlib.FMT_XML)
+        )
+        status, output = _capture_main(
+            ["--root", str(root), "--account-slug", "neutral-owner", "--no-registry"]
+        )
+        _selftest_check(
+            status == 1
+            and "denylist: fixture.plist:" in output
+            and "binary files skipped: 0" in output,
+            "UTF-8 plist is scanned before binary classification: %r" % output,
+        )
+
+    with tempfile.TemporaryDirectory() as temporary:
+        root = Path(temporary)
         _materialize_fixture(root, SELFTEST_VIOLATING_README)
         status, output = _capture_main(
             ["--root", str(root), "--account-slug", "neutral-owner", "--no-registry"]
@@ -1166,7 +1346,8 @@ def selftest_end_to_end():
         _selftest_check(
             no_registry_status == 1
             and "gate-error: registry/modules.json exists under --root but --no-registry was passed (fail-closed)"
-            in no_registry_output,
+            in no_registry_output
+            and "notice:" not in no_registry_output,
             "conventional registry rejects explicit opt-out: %r" % no_registry_output,
         )
         conflicting_status, conflicting_output = _capture_main(

--- a/templates/publication-gate/check_publication_gate.py
+++ b/templates/publication-gate/check_publication_gate.py
@@ -616,6 +616,11 @@ def run_gate(
             "gate-error: registry/modules.json exists under --root but --no-registry was passed "
             "(fail-closed)"
         )
+    if no_registry and registry_argument is None and whitelist:
+        failures.append(
+            "gate-error: .publication-label-whitelist has entries but --no-registry was passed "
+            "(fail-closed; whitelist staleness cannot be checked without a registry)"
+        )
 
     registry_path = None
     if registry_argument is not None:
@@ -673,7 +678,7 @@ def run_gate(
     print("module links checked : %d" % root_links)
     print("SVG names checked    : %d" % svg_names)
     print("label whitelist      : %d" % len(whitelist))
-    if no_registry and registry_argument is None and not conventional_registry_exists:
+    if no_registry and registry_argument is None and not conventional_registry_exists and not whitelist:
         for notice in SKIP_NOTICES:
             print(notice)
 
@@ -690,6 +695,13 @@ SELFTEST_DENYLIST = (
     "# Embedded policy fixture.\n"
     "private-marker\tacme[-_ ]" "secret\n"
     "private-host\tprivate\\.example\\.invalid\n"
+)
+SELFTEST_SAMPLE_DENYLIST = (
+    "# Copy this file to the repository root as .publication-denylist and customize it.\n"
+    "private-marker\tacme[-_ ]secret\n"
+    "private-host\tprivate\\.example\\.invalid\n"
+    "# Keep local@host/... coverage in denylist territory.\n"
+    "email-address\t\\b[A-Z0-9._%+\\-]+@[A-Z0-9.\\-]+\\.[A-Z]{2,}\\b\n"
 )
 SELFTEST_CLEAN_README = "# Public project\n\nPublication-safe example content.\n"
 SELFTEST_VIOLATING_README = (
@@ -789,6 +801,12 @@ def selftest_policy_parsers():
             encoding="utf-8",
         )
         _selftest_check(len(load_denylist(root)) == 1, "BOM comment and explicit whitespace regex")
+        shipped_sample = Path(__file__).resolve().parent / "fixtures" / "sample.publication-denylist"
+        if shipped_sample.is_file():
+            _selftest_check(
+                shipped_sample.read_bytes() == SELFTEST_SAMPLE_DENYLIST.encode("utf-8"),
+                "shipped sample denylist stays byte-identical",
+            )
         _selftest_check(load_label_whitelist(root) == frozenset(), "absent whitelist")
         (root / WHITELIST_NAME).write_text("README.md\tapproved exact line\n", encoding="utf-8")
         _selftest_check(("README.md", "approved exact line") in load_label_whitelist(root), "whitelist parser")
@@ -949,6 +967,21 @@ def selftest_scanners():
         == 1
         and "neutral-owner/private-repo" in dash_at_failures[0],
         "dash-at personal repository URL",
+    )
+    bang_at_failures = []
+    _selftest_check(
+        check_personal_urls(
+            {"README.md": "bob!@" + _fixture_personal_url(
+                "neutral-owner", "private-repo"
+            )[len("https://") :]},
+            "neutral-owner",
+            None,
+            bang_at_failures,
+        )
+        == 1
+        and len(bang_at_failures) == 1
+        and "neutral-owner/private-repo" in bang_at_failures[0],
+        "bang-at personal repository URL",
     )
     encoded_at_failures = []
     encoded_at = _fixture_personal_url(
@@ -1188,15 +1221,15 @@ def selftest_end_to_end():
         root = Path(temporary)
         _materialize_fixture(root)
         protected_text = ("acme-" "secret\n").encode("utf-8") + b"\xff\n"
-        (root / "secret.md").write_bytes(protected_text)
+        (root / "SECRET.MD").write_bytes(protected_text)
         status, output = _capture_main(
             ["--root", str(root), "--account-slug", "neutral-owner", "--no-registry"]
         )
         _selftest_check(
             status == 1
-            and "source-read: secret.md is not valid UTF-8 text (fail-closed)" in output
+            and "source-read: SECRET.MD is not valid UTF-8 text (fail-closed)" in output
             and "binary files skipped: 0" in output,
-            "non-UTF-8 text suffix fails closed: %r" % output,
+            "case-folded non-UTF-8 text suffix fails closed: %r" % output,
         )
 
     with tempfile.TemporaryDirectory() as temporary:
@@ -1396,6 +1429,24 @@ def selftest_end_to_end():
     with tempfile.TemporaryDirectory() as temporary:
         root = Path(temporary)
         _materialize_fixture(root)
+        (root / WHITELIST_NAME).write_text(
+            "README.md\tapproved exact line\n",
+            encoding="utf-8",
+        )
+        status, output = _capture_main(
+            ["--root", str(root), "--account-slug", "neutral-owner", "--no-registry"]
+        )
+        _selftest_check(
+            status == 1
+            and "gate-error: .publication-label-whitelist has entries but --no-registry was passed (fail-closed; whitelist staleness cannot be checked without a registry)"
+            in output
+            and "notice:" not in output,
+            "non-empty whitelist rejects explicit no-registry opt-out: %r" % output,
+        )
+
+    with tempfile.TemporaryDirectory() as temporary:
+        root = Path(temporary)
+        _materialize_fixture(root)
         (root / ".gitignore").write_text("node_modules/\n*.txt\n", encoding="utf-8")
         (root / "node_modules").mkdir()
         (root / "node_modules" / "x.md").write_text(
@@ -1435,6 +1486,38 @@ def selftest_end_to_end():
     with tempfile.TemporaryDirectory() as temporary:
         root = Path(temporary)
         _materialize_fixture(root)
+        (root / "notes.md").write_bytes(b"\x80\x81\x82")
+        _initialize_git_fixture(root, ("README.md", DENYLIST_NAME, "notes.md"))
+        status, output = _capture_main(
+            ["--root", str(root), "--account-slug", "neutral-owner", "--no-registry"]
+        )
+        _selftest_check(
+            status == 1
+            and "enumeration: git" in output
+            and "source-read: notes.md is not valid UTF-8 text (fail-closed)" in output
+            and "binary files skipped: 0" in output,
+            "git non-UTF-8 text suffix fails closed: %r" % output,
+        )
+
+    with tempfile.TemporaryDirectory() as temporary:
+        root = Path(temporary)
+        _materialize_fixture(root)
+        (root / "logo.png").write_bytes(b"\x80\x81\x82")
+        _initialize_git_fixture(root, ("README.md", DENYLIST_NAME, "logo.png"))
+        status, output = _capture_main(
+            ["--root", str(root), "--account-slug", "neutral-owner", "--no-registry"]
+        )
+        _selftest_check(
+            status == 0
+            and "enumeration: git" in output
+            and "binary files skipped: 1" in output
+            and "  skipped (binary): logo.png" in output,
+            "git non-UTF-8 PNG is skipped and listed: %r" % output,
+        )
+
+    with tempfile.TemporaryDirectory() as temporary:
+        root = Path(temporary)
+        _materialize_fixture(root)
         os.symlink("https://github." "com/neutral-owner/private", root / "published-link")
         _initialize_git_fixture(root, ("README.md", DENYLIST_NAME, "published-link"))
         status, output = _capture_main(
@@ -1460,6 +1543,25 @@ def selftest_end_to_end():
         _selftest_check(
             status == 1 and "denylist: README.md:1 contains email-address" in output,
             "main-level slug-domain email denylist: %r" % output,
+        )
+
+    with tempfile.TemporaryDirectory() as temporary:
+        root = Path(temporary)
+        _materialize_fixture(
+            root,
+            "Contact bob@"
+            + _fixture_personal_url("neutral-owner", "private-repo")[len("https://") :]
+            + "\n",
+            SELFTEST_SAMPLE_DENYLIST,
+        )
+        status, output = _capture_main(
+            ["--root", str(root), "--account-slug", "neutral-owner", "--no-registry"]
+        )
+        _selftest_check(
+            status == 1
+            and "denylist rules loaded : 3" in output
+            and "denylist: README.md:1 contains email-address" in output,
+            "shipped sample denylist catches slug-domain email fixture: %r" % output,
         )
 
     with tempfile.TemporaryDirectory() as temporary:

--- a/templates/publication-gate/check_publication_gate.py
+++ b/templates/publication-gate/check_publication_gate.py
@@ -16,7 +16,6 @@ import io
 import json
 import os
 from pathlib import Path
-import plistlib
 import re
 import shutil
 import stat
@@ -34,25 +33,27 @@ WHITELIST_NAME = ".publication-label-whitelist"
 ACCOUNT_SLUG = re.compile(r"^[A-Za-z0-9](?:[A-Za-z0-9-]{0,37})$")
 BINARY_SUFFIXES = frozenset(
     (
-        ".png", ".jpg", ".jpeg", ".gif", ".webp", ".ico", ".bmp", ".tif",
-        ".tiff", ".avif", ".heic", ".heif", ".psd", ".svgz", ".woff", ".woff2",
-        ".ttf", ".otf", ".eot", ".zip", ".gz", ".tgz", ".tar", ".bz2", ".xz",
-        ".zst", ".7z", ".rar", ".jar", ".war", ".whl", ".egg", ".gem", ".nupkg",
+        ".png", ".jpg", ".jpeg", ".gif", ".webp", ".ico", ".icns", ".bmp", ".tif",
+        ".tiff", ".avif", ".heic", ".heif", ".jfif", ".psd", ".ai", ".eps", ".sketch",
+        ".fig", ".glb", ".gltf", ".svgz", ".woff", ".woff2", ".ttf", ".ttc", ".otf",
+        ".eot", ".zip", ".gz", ".tgz", ".tar", ".bz2", ".xz", ".zst", ".lz4", ".7z",
+        ".rar", ".iso", ".img", ".jar", ".war", ".whl", ".egg", ".gem", ".nupkg",
         ".deb", ".rpm", ".dmg", ".pkg", ".apk", ".ipa", ".pdf", ".doc", ".docx",
-        ".xls", ".xlsx", ".ppt", ".pptx", ".key", ".numbers", ".pages", ".odt",
-        ".ods", ".odp", ".mp3", ".mp4", ".m4a", ".m4v", ".mov", ".avi", ".mkv",
-        ".webm", ".wav", ".flac", ".ogg", ".oga", ".ogv", ".aac", ".aif", ".aiff",
-        ".so", ".dylib", ".dll", ".exe", ".o", ".a", ".lib", ".obj", ".class",
-        ".pyc", ".pyd", ".wasm", ".bin", ".dat", ".db", ".sqlite", ".sqlite3",
-        ".pak", ".bundle", ".mo", ".pb", ".onnx", ".npy", ".npz", ".parquet",
-        ".arrow", ".pickle", ".pkl", ".h5", ".hdf5", ".plist",
+        ".xls", ".xlsx", ".ppt", ".pptx", ".numbers", ".pages", ".odt", ".ods", ".odp",
+        ".mp3", ".mp4", ".m4a", ".m4v", ".mov", ".avi", ".mkv", ".webm", ".wav",
+        ".flac", ".ogg", ".oga", ".ogv", ".aac", ".aif", ".aiff", ".flv", ".mpg",
+        ".mpeg", ".wmv", ".opus", ".mid", ".midi", ".swf", ".so", ".dylib", ".dll",
+        ".exe", ".o", ".a", ".lib", ".obj", ".class", ".node", ".pdb", ".rlib",
+        ".xcuserstate", ".pyc", ".pyd", ".wasm", ".bin", ".dat", ".db", ".mdb", ".rdb",
+        ".sqlite", ".sqlite3", ".pak", ".bundle", ".mo", ".pb", ".onnx", ".npy", ".npz",
+        ".parquet", ".arrow", ".pickle", ".pkl", ".h5", ".hdf5",
     )
 )
 URL_CANDIDATE = re.compile(
-    r"(?<![A-Za-z0-9._-])(?<![A-Za-z0-9_%+]@)"
+    r"(?<![A-Za-z0-9._-])(?<![A-Za-z0-9_]@)(?<![A-Za-z0-9_][%+]@)"
     r"(?:https?://(?:[A-Za-z0-9._~!$&'()*+,;=:%-]+@)?)?"
     r"(?:[A-Za-z0-9-]+\.)+[A-Za-z0-9-]+\.?(?::[0-9]+)?"
-    r"(?:/[^\s<>'\"`()\[\]{}]*)?",
+    r"(?:[\\/][^\s<>'\"`()\[\]{}]*)?",
     re.IGNORECASE,
 )
 LANG_SUFFIX = re.compile(r"\.(?P<lang>[a-z]{2}(?:-[a-z]{2})?)\.md$")
@@ -282,10 +283,15 @@ def read_sources(root, failures, excluded_policy_path):
             if not stat.S_ISREG(mode):
                 failures.append("source-read: %s is not a regular file" % relative)
                 continue
+            raw = path.read_bytes()
             try:
-                documents[relative] = path.read_bytes().decode("utf-8")
+                documents[relative] = raw.decode("utf-8")
             except UnicodeDecodeError:
-                if path.suffix.lower() in BINARY_SUFFIXES or path.name == ".DS_Store":
+                if (
+                    path.suffix.lower() in BINARY_SUFFIXES
+                    or path.name == ".DS_Store"
+                    or raw.startswith(b"bplist00")
+                ):
                     binary_skipped += 1
                     binary_skipped_paths.append(relative)
                 else:
@@ -322,6 +328,7 @@ def check_denylist(documents, rules, failures):
 
 
 def _personal_url(candidate, account_slug):
+    candidate = candidate.replace("\\", "/")
     candidate = candidate.rstrip(".,;:!?")
     parsed = urllib.parse.urlsplit(candidate if "://" in candidate else "//" + candidate)
     host = (parsed.hostname or "").casefold()
@@ -340,17 +347,26 @@ def _personal_url(candidate, account_slug):
     return False
 
 
-def _nested_personal_url(candidate, account_slug):
-    repo_name = _personal_url(candidate, account_slug)
-    if repo_name is not False:
-        return repo_name
-    for index, character in enumerate(candidate):
-        if character != "/":
+def _nested_personal_urls(candidate, account_slug):
+    """Yield every distinct personal URL found at a nested URL boundary."""
+    candidate = candidate.replace("\\", "/")
+    reported = set()
+    split_characters = "/?#=&\\"
+    for index in range(-1, len(candidate)):
+        if index >= 0 and candidate[index] not in split_characters:
             continue
         repo_name = _personal_url(candidate[index + 1 :], account_slug)
-        if repo_name is not False:
-            return repo_name
-    return False
+        if repo_name is False:
+            continue
+        folded = (
+            account_slug
+            if repo_name is None
+            else account_slug + "/" + repo_name
+        ).casefold()
+        if folded in reported:
+            continue
+        reported.add(folded)
+        yield repo_name
 
 
 def registry_allowlist(registry):
@@ -368,32 +384,30 @@ def check_personal_urls(documents, account_slug, registry, failures):
         reported = set()
         for view_index, view in enumerate(scan_views(text)):
             for match in URL_CANDIDATE.finditer(view):
-                repo_name = _nested_personal_url(match.group(0), account_slug)
-                if repo_name is False:
-                    continue
                 number = line_number(view, match.start())
-                repo = "%s/%s" % (account_slug, repo_name) if repo_name else account_slug
-                finding = (number, repo.casefold())
-                if finding in reported:
-                    continue
-                reported.add(finding)
-                checked += 1
-                view_marker = "" if view_index == 0 else " (decoded view)"
-                if repo_name is None:
-                    failures.append(
-                        "personal-url: %s:%d references personal account profile %s%s"
-                        % (path, number, account_slug, view_marker)
-                    )
-                elif allowlist is None:
-                    failures.append(
-                        "personal-url: %s:%d references personal account repository %s%s"
-                        % (path, number, repo, view_marker)
-                    )
-                elif repo.casefold() not in allowlist:
-                    failures.append(
-                        "personal-url: %s:%d references unknown repository %s%s"
-                        % (path, number, repo, view_marker)
-                    )
+                for repo_name in _nested_personal_urls(match.group(0), account_slug):
+                    repo = "%s/%s" % (account_slug, repo_name) if repo_name else account_slug
+                    finding = (number, repo.casefold())
+                    if finding in reported:
+                        continue
+                    reported.add(finding)
+                    checked += 1
+                    view_marker = "" if view_index == 0 else " (decoded view)"
+                    if repo_name is None:
+                        failures.append(
+                            "personal-url: %s:%d references personal account profile %s%s"
+                            % (path, number, account_slug, view_marker)
+                        )
+                    elif allowlist is None:
+                        failures.append(
+                            "personal-url: %s:%d references personal account repository %s%s"
+                            % (path, number, repo, view_marker)
+                        )
+                    elif repo.casefold() not in allowlist:
+                        failures.append(
+                            "personal-url: %s:%d references unknown repository %s%s"
+                            % (path, number, repo, view_marker)
+                        )
     return checked
 
 
@@ -954,6 +968,40 @@ def selftest_scanners():
         and not email_context_failures,
         "email-context personal URL remains denylist territory",
     )
+    for prefix in ("+@", "%@"):
+        prefixed_failures = []
+        _selftest_check(
+            check_personal_urls(
+                {
+                    "README.md": prefix
+                    + _fixture_personal_url("neutral-owner", "private-repo")[len("https://") :]
+                },
+                "neutral-owner",
+                None,
+                prefixed_failures,
+            )
+            == 1
+            and len(prefixed_failures) == 1
+            and "neutral-owner/private-repo" in prefixed_failures[0],
+            "%s prefixed bare personal repository URL" % prefix,
+        )
+    for local_part in ("bob+tag", "x%", "bob"):
+        tagged_email_failures = []
+        _selftest_check(
+            check_personal_urls(
+                {
+                    "README.md": local_part
+                    + "@"
+                    + _fixture_personal_url("neutral-owner", "private-repo")[len("https://") :]
+                },
+                "neutral-owner",
+                None,
+                tagged_email_failures,
+            )
+            == 0
+            and not tagged_email_failures,
+            "%s email remains denylist territory" % local_part,
+        )
     dash_at_failures = []
     _selftest_check(
         check_personal_urls(
@@ -1045,6 +1093,53 @@ def selftest_scanners():
         and not unrelated_nested_failures,
         "nested personal URL unrelated-host control",
     )
+    nested_separator_cases = (
+        (
+            "https://example.com/x?u=github." "com/neutral-owner/query",
+            "neutral-owner/query",
+            "query-string nested personal URL",
+        ),
+        (
+            "https://example.com/a#github." "com/neutral-owner/frag",
+            "neutral-owner/frag",
+            "fragment nested personal URL",
+        ),
+        (
+            "https://github." "com\\/neutral-owner\\/private-repo",
+            "neutral-owner/private-repo",
+            "backslash-separated absolute personal URL",
+        ),
+        (
+            "github." "com\\/neutral-owner\\/private-repo",
+            "neutral-owner/private-repo",
+            "backslash-separated bare personal URL",
+        ),
+    )
+    for source, expected_repo, description in nested_separator_cases:
+        separator_failures = []
+        candidates = tuple(match.group(0) for match in URL_CANDIDATE.finditer(source))
+        _selftest_check(
+            check_personal_urls(
+                {"README.md": source}, "neutral-owner", None, separator_failures
+            )
+            == 1
+            and len(separator_failures) == 1
+            and expected_repo in separator_failures[0]
+            and candidates == (source,),
+            description,
+        )
+    nested_query_control_failures = []
+    _selftest_check(
+        check_personal_urls(
+            {"README.md": "https://example.org/docs?q=neutral-owner"},
+            "neutral-owner",
+            None,
+            nested_query_control_failures,
+        )
+        == 0
+        and not nested_query_control_failures,
+        "nested query unrelated-host control",
+    )
 
     normalized_failures = []
     normalized_documents = {
@@ -1097,6 +1192,20 @@ def selftest_scanners():
         ) == 1 and unknown_failures,
         "unknown personal repository",
     )
+    for source in (
+        "https://github." "com/neutral-owner/public-archive/github." "com/neutral-owner/private-repo",
+        "https://github." "com/neutral-owner/private-repo/github." "com/neutral-owner/public-archive",
+    ):
+        smuggle_failures = []
+        _selftest_check(
+            check_personal_urls(
+                {"README.md": source}, "neutral-owner", registry, smuggle_failures
+            )
+            == 2
+            and len(smuggle_failures) == 1
+            and "neutral-owner/private-repo" in smuggle_failures[0],
+            "allowlist cannot smuggle nested private repository: %s" % source,
+        )
 
 
 def selftest_registry_checks():
@@ -1152,6 +1261,8 @@ def _initialize_git_fixture(root, paths):
 
 
 def selftest_end_to_end():
+    import plistlib
+
     with tempfile.TemporaryDirectory() as temporary:
         root = Path(temporary)
         _materialize_fixture(root)
@@ -1292,6 +1403,34 @@ def selftest_end_to_end():
     with tempfile.TemporaryDirectory() as temporary:
         root = Path(temporary)
         _materialize_fixture(root)
+        (root / "id_rsa.key").write_bytes(b"\x30\x82\xff\x00")
+        status, output = _capture_main(
+            ["--root", str(root), "--account-slug", "neutral-owner", "--no-registry"]
+        )
+        _selftest_check(
+            status == 1
+            and "source-read: id_rsa.key is not valid UTF-8 text (fail-closed)" in output
+            and "binary files skipped: 0" in output,
+            "non-UTF-8 key file fails closed: %r" % output,
+        )
+
+    with tempfile.TemporaryDirectory() as temporary:
+        root = Path(temporary)
+        _materialize_fixture(root)
+        (root / "icon.icns").write_bytes(b"\xff\xfe\x00")
+        status, output = _capture_main(
+            ["--root", str(root), "--account-slug", "neutral-owner", "--no-registry"]
+        )
+        _selftest_check(
+            status == 0
+            and "binary files skipped: 1" in output
+            and "  skipped (binary): icon.icns" in output,
+            "non-UTF-8 ICNS is skipped and listed: %r" % output,
+        )
+
+    with tempfile.TemporaryDirectory() as temporary:
+        root = Path(temporary)
+        _materialize_fixture(root)
         (root / "fixture.plist").write_bytes(
             plistlib.dumps({"note": "x"}, fmt=plistlib.FMT_BINARY)
         )
@@ -1303,6 +1442,22 @@ def selftest_end_to_end():
             and "binary files skipped: 1" in output
             and "  skipped (binary): fixture.plist" in output,
             "binary plist is skipped and listed: %r" % output,
+        )
+
+    with tempfile.TemporaryDirectory() as temporary:
+        root = Path(temporary)
+        _materialize_fixture(root)
+        (root / "fixture.xml").write_bytes(
+            plistlib.dumps({"note": "x"}, fmt=plistlib.FMT_BINARY)
+        )
+        status, output = _capture_main(
+            ["--root", str(root), "--account-slug", "neutral-owner", "--no-registry"]
+        )
+        _selftest_check(
+            status == 0
+            and "binary files skipped: 1" in output
+            and "  skipped (binary): fixture.xml" in output,
+            "binary plist signature skips any suffix: %r" % output,
         )
 
     with tempfile.TemporaryDirectory() as temporary:
@@ -1333,6 +1488,24 @@ def selftest_end_to_end():
             and "denylist: fixture.plist:" in output
             and "binary files skipped: 0" in output,
             "UTF-8 plist is scanned before binary classification: %r" % output,
+        )
+
+    with tempfile.TemporaryDirectory() as temporary:
+        root = Path(temporary)
+        _materialize_fixture(root)
+        (root / "fixture.plist").write_bytes(
+            plistlib.dumps({"note": "acme-" "secret"}, fmt=plistlib.FMT_XML)
+            .decode("utf-8")
+            .encode("utf-16")
+        )
+        status, output = _capture_main(
+            ["--root", str(root), "--account-slug", "neutral-owner", "--no-registry"]
+        )
+        _selftest_check(
+            status == 1
+            and "source-read: fixture.plist is not valid UTF-8 text (fail-closed)" in output
+            and "binary files skipped: 0" in output,
+            "UTF-16 XML plist fails closed as source text: %r" % output,
         )
 
     with tempfile.TemporaryDirectory() as temporary:
@@ -1562,6 +1735,25 @@ def selftest_end_to_end():
             and "denylist rules loaded : 3" in output
             and "denylist: README.md:1 contains email-address" in output,
             "shipped sample denylist catches slug-domain email fixture: %r" % output,
+        )
+
+    with tempfile.TemporaryDirectory() as temporary:
+        root = Path(temporary)
+        _materialize_fixture(
+            root,
+            "Contact bob+tag@"
+            + _fixture_personal_url("neutral-owner", "private-repo")[len("https://") :]
+            + "\n",
+            SELFTEST_SAMPLE_DENYLIST,
+        )
+        status, output = _capture_main(
+            ["--root", str(root), "--account-slug", "neutral-owner", "--no-registry"]
+        )
+        _selftest_check(
+            status == 1
+            and "denylist: README.md:1 contains email-address" in output
+            and "personal-url:" not in output,
+            "shipped sample denylist catches tagged email fixture: %r" % output,
         )
 
     with tempfile.TemporaryDirectory() as temporary:

--- a/templates/publication-gate/check_publication_gate.py
+++ b/templates/publication-gate/check_publication_gate.py
@@ -3,7 +3,8 @@
 
 The denylist is repository policy, not checker source.  Normal runs require an
 account slug so personal-account URLs are always checked.  Registry-backed
-label, SVG, allowlist, and whitelist-staleness checks are optional.
+label, SVG, allowlist, and whitelist-staleness checks may be opted out of only
+with an explicit --no-registry declaration.
 
 Python 3.9+, standard library only.
 """
@@ -30,8 +31,25 @@ EXCLUDED_DIRS = frozenset(
 DENYLIST_NAME = ".publication-denylist"
 WHITELIST_NAME = ".publication-label-whitelist"
 ACCOUNT_SLUG = re.compile(r"^[A-Za-z0-9](?:[A-Za-z0-9-]{0,37})$")
+TEXT_SUFFIXES = frozenset(
+    (
+        ".md", ".markdown", ".mdx", ".txt", ".text", ".rst", ".adoc", ".svg",
+        ".json", ".jsonc", ".json5", ".yml", ".yaml", ".toml", ".ini", ".cfg",
+        ".conf", ".env", ".xml", ".html", ".htm", ".css", ".scss", ".less",
+        ".js", ".mjs", ".cjs", ".ts", ".tsx", ".jsx", ".py", ".pyi", ".sh",
+        ".bash", ".zsh", ".fish", ".rb", ".go", ".rs", ".java", ".kt", ".kts",
+        ".swift", ".c", ".h", ".cc", ".cpp", ".hpp", ".m", ".mm", ".php",
+        ".pl", ".lua", ".sql", ".csv", ".tsv", ".tex", ".bib", ".ps1", ".bat",
+        ".cmd", ".properties", ".lock", ".mk", ".cmake", ".gradle", ".plist",
+        ".graphql", ".proto", ".tf", ".hcl", ".vue", ".svelte", ".astro", ".njk",
+        ".hbs", ".ejs", ".pug", ".diff", ".patch", ".log", ".cff", ".bzl", ".nix",
+        ".dart", ".scala", ".clj", ".ex", ".exs", ".erl", ".hs", ".ml", ".r",
+        ".jl",
+    )
+)
 URL_CANDIDATE = re.compile(
-    r"(?<![A-Za-z0-9@._-])(?:https?://(?:[A-Za-z0-9._~!$&'()*+,;=:%-]+@)?)?"
+    r"(?<![A-Za-z0-9._-])(?<![A-Za-z0-9._%+-]@)"
+    r"(?:https?://(?:[A-Za-z0-9._~!$&'()*+,;=:%-]+@)?)?"
     r"(?:[A-Za-z0-9-]+\.)+[A-Za-z0-9-]+\.?(?::[0-9]+)?"
     r"(?:/[^\s<>'\"`()\[\]{}]*)?",
     re.IGNORECASE,
@@ -245,6 +263,7 @@ def iter_source_paths(root, excluded_policy_path):
 def read_sources(root, failures, excluded_policy_path):
     documents = {}
     binary_skipped = 0
+    binary_skipped_paths = []
     symlinks_skipped = 0
     paths, enumeration_mode = iter_source_paths(root, excluded_policy_path)
     for path in paths:
@@ -265,10 +284,16 @@ def read_sources(root, failures, excluded_policy_path):
             try:
                 documents[relative] = path.read_bytes().decode("utf-8")
             except UnicodeDecodeError:
-                binary_skipped += 1
+                if path.suffix.lower() in TEXT_SUFFIXES or path.suffix == "":
+                    failures.append(
+                        "source-read: %s is not valid UTF-8 text (fail-closed)" % relative
+                    )
+                else:
+                    binary_skipped += 1
+                    binary_skipped_paths.append(relative)
         except OSError as exc:
             failures.append("source-read: %s could not be read: %s" % (relative, exc))
-    return documents, enumeration_mode, binary_skipped, symlinks_skipped
+    return documents, enumeration_mode, binary_skipped, symlinks_skipped, binary_skipped_paths
 
 
 def check_denylist(documents, rules, failures):
@@ -515,7 +540,13 @@ SKIP_NOTICES = (
 )
 
 
-def run_gate(root, account_slug, registry_argument=None, denylist_argument=None):
+def run_gate(
+    root,
+    account_slug,
+    registry_argument=None,
+    denylist_argument=None,
+    no_registry=False,
+):
     root = Path(root).expanduser().resolve()
     failures = []
     documents = {}
@@ -530,6 +561,7 @@ def run_gate(root, account_slug, registry_argument=None, denylist_argument=None)
     svg_names = 0
     enumeration_mode = "git" if _contains_git_entry(root) else "rglob-fallback"
     binary_skipped = 0
+    binary_skipped_paths = []
     symlinks_skipped = 0
     policy_path = denylist_path(root, denylist_argument)
 
@@ -550,6 +582,25 @@ def run_gate(root, account_slug, registry_argument=None, denylist_argument=None)
         whitelist = load_label_whitelist(root)
     except GateConfigurationError as exc:
         failures.append(str(exc))
+
+    if registry_argument is None and not no_registry:
+        failures.append(
+            "gate-error: --registry is required unless --no-registry is passed explicitly "
+            "(fail-closed; registry-backed checks are never skipped silently)"
+        )
+    if registry_argument is not None and no_registry:
+        failures.append(
+            "gate-error: --registry and --no-registry are mutually exclusive (fail-closed)"
+        )
+    if (
+        no_registry
+        and registry_argument is None
+        and (root / "registry" / "modules.json").is_file()
+    ):
+        failures.append(
+            "gate-error: registry/modules.json exists under --root but --no-registry was passed "
+            "(fail-closed)"
+        )
 
     registry_path = None
     if registry_argument is not None:
@@ -572,9 +623,13 @@ def run_gate(root, account_slug, registry_argument=None, denylist_argument=None)
                 failures.append(str(exc))
 
     try:
-        documents, enumeration_mode, binary_skipped, symlinks_skipped = read_sources(
-            root, failures, policy_path
-        )
+        (
+            documents,
+            enumeration_mode,
+            binary_skipped,
+            symlinks_skipped,
+            binary_skipped_paths,
+        ) = read_sources(root, failures, policy_path)
         check_corpus_floor(documents, corpus_anchor, failures)
         if rules:
             denylist_hits = check_denylist(documents, rules, failures)
@@ -593,6 +648,8 @@ def run_gate(root, account_slug, registry_argument=None, denylist_argument=None)
     print("enumeration: %s" % enumeration_mode)
     print("source files scanned : %d" % len(documents))
     print("binary files skipped: %d" % binary_skipped)
+    for relative in binary_skipped_paths:
+        print("  skipped (binary): %s" % relative)
     if enumeration_mode == "rglob-fallback":
         print("symlinks skipped: %d" % symlinks_skipped)
     print("denylist rules loaded : %d" % len(rules))
@@ -601,7 +658,7 @@ def run_gate(root, account_slug, registry_argument=None, denylist_argument=None)
     print("module links checked : %d" % root_links)
     print("SVG names checked    : %d" % svg_names)
     print("label whitelist      : %d" % len(whitelist))
-    if registry_argument is None:
+    if no_registry and registry_argument is None:
         for notice in SKIP_NOTICES:
             print(notice)
 
@@ -821,6 +878,50 @@ def selftest_scanners():
         "userinfo clean host control",
     )
 
+    bare_repo_failures = []
+    bare_repo = "@" + _fixture_personal_url(
+        "neutral-owner", "private-repo"
+    )[len("https://") :]
+    _selftest_check(
+        check_personal_urls(
+            {"README.md": "see " + bare_repo},
+            "neutral-owner",
+            None,
+            bare_repo_failures,
+        )
+        == 1
+        and "neutral-owner/private-repo" in bare_repo_failures[0],
+        "bare-at personal repository URL",
+    )
+    bare_profile_failures = []
+    bare_profile = "@" + _fixture_personal_url("neutral-owner")[len("https://") :]
+    _selftest_check(
+        check_personal_urls(
+            {"README.md": "(" + bare_profile + ")"},
+            "neutral-owner",
+            None,
+            bare_profile_failures,
+        )
+        == 1
+        and "personal account profile" in bare_profile_failures[0],
+        "bare-at personal account profile",
+    )
+    email_context_failures = []
+    email_context = "bob@" + _fixture_personal_url(
+        "neutral-owner", "private-repo"
+    )[len("https://") :]
+    _selftest_check(
+        check_personal_urls(
+            {"README.md": email_context},
+            "neutral-owner",
+            None,
+            email_context_failures,
+        )
+        == 0
+        and not email_context_failures,
+        "email-context personal URL remains denylist territory",
+    )
+
     normalized_failures = []
     normalized_documents = {
         "README.md": "\n".join(
@@ -941,15 +1042,20 @@ def selftest_end_to_end():
             "acme-" "secret\n", encoding="utf-8"
         )
         os.symlink("README.md", root / "readme-link")
-        status, output = _capture_main(["--root", str(root), "--account-slug", "neutral-owner"])
+        status, output = _capture_main(
+            ["--root", str(root), "--account-slug", "neutral-owner", "--no-registry"]
+        )
         _selftest_check(status == 0, "clean fixture main(): %r" % output)
         _selftest_check(all(notice in output for notice in SKIP_NOTICES), "four registry skip notices")
         _selftest_check("enumeration: rglob-fallback" in output, "fallback enumeration summary")
         _selftest_check("source files scanned : 6" in output, "all UTF-8 suffixes and extensionless files scanned")
         _selftest_check("binary files skipped: 1" in output, "binary summary")
+        _selftest_check("  skipped (binary): image.bin" in output, "binary path summary")
         _selftest_check("symlinks skipped: 1" in output, "fallback symlink summary")
         _selftest_check("denylist rules loaded : 2" in output, "denylist rule summary")
-        missing_slug_status, missing_slug_output = _capture_main(["--root", str(root)])
+        missing_slug_status, missing_slug_output = _capture_main(
+            ["--root", str(root), "--no-registry"]
+        )
         _selftest_check(
             missing_slug_status == 1
             and "gate-error: --account-slug is required for publication URL checks (fail-closed)"
@@ -957,14 +1063,14 @@ def selftest_end_to_end():
             "missing account slug fails closed",
         )
         whitespace_status, whitespace_output = _capture_main(
-            ["--root", str(root), "--account-slug", " "]
+            ["--root", str(root), "--account-slug", " ", "--no-registry"]
         )
         _selftest_check(
             whitespace_status == 1 and "gate-error: --account-slug" in whitespace_output,
             "whitespace account slug fails closed",
         )
         invalid_slug_status, invalid_slug_output = _capture_main(
-            ["--root", str(root), "--account-slug", "foo/bar"]
+            ["--root", str(root), "--account-slug", "foo/bar", "--no-registry"]
         )
         _selftest_check(
             invalid_slug_status == 1
@@ -975,8 +1081,53 @@ def selftest_end_to_end():
 
     with tempfile.TemporaryDirectory() as temporary:
         root = Path(temporary)
+        _materialize_fixture(root)
+        status, output = _capture_main(
+            ["--root", str(root), "--account-slug", "neutral-owner"]
+        )
+        _selftest_check(
+            status == 1
+            and "gate-error: --registry is required unless --no-registry is passed explicitly"
+            in output
+            and all(notice not in output for notice in SKIP_NOTICES),
+            "registry omission fails closed without skip notices: %r" % output,
+        )
+
+    with tempfile.TemporaryDirectory() as temporary:
+        root = Path(temporary)
+        _materialize_fixture(root)
+        protected_text = ("acme-" "secret\n").encode("utf-8") + b"\xff\n"
+        (root / "secret.md").write_bytes(protected_text)
+        status, output = _capture_main(
+            ["--root", str(root), "--account-slug", "neutral-owner", "--no-registry"]
+        )
+        _selftest_check(
+            status == 1
+            and "source-read: secret.md is not valid UTF-8 text (fail-closed)" in output
+            and "binary files skipped: 0" in output,
+            "non-UTF-8 text suffix fails closed: %r" % output,
+        )
+
+    with tempfile.TemporaryDirectory() as temporary:
+        root = Path(temporary)
+        _materialize_fixture(root)
+        (root / "NOTICE").write_bytes(b"\x80abc\n")
+        status, output = _capture_main(
+            ["--root", str(root), "--account-slug", "neutral-owner", "--no-registry"]
+        )
+        _selftest_check(
+            status == 1
+            and "source-read: NOTICE is not valid UTF-8 text (fail-closed)" in output
+            and "binary files skipped: 0" in output,
+            "non-UTF-8 extensionless file fails closed: %r" % output,
+        )
+
+    with tempfile.TemporaryDirectory() as temporary:
+        root = Path(temporary)
         _materialize_fixture(root, SELFTEST_VIOLATING_README)
-        status, output = _capture_main(["--root", str(root), "--account-slug", "neutral-owner"])
+        status, output = _capture_main(
+            ["--root", str(root), "--account-slug", "neutral-owner", "--no-registry"]
+        )
         _selftest_check(status == 1 and "denylist:" in output, "violating fixture main()")
 
     with tempfile.TemporaryDirectory() as temporary:
@@ -985,11 +1136,13 @@ def selftest_end_to_end():
         copied_gate = root / "tools" / "check_publication_gate.py"
         copied_gate.parent.mkdir(parents=True)
         shutil.copyfile(Path(__file__), copied_gate)
-        status, output = _capture_main(["--root", str(root), "--account-slug", "neutral-owner"])
+        status, output = _capture_main(
+            ["--root", str(root), "--account-slug", "neutral-owner", "--no-registry"]
+        )
         _selftest_check(status == 0 and "source files scanned : 2" in output, "copied gate self-scan: %r" % output)
         (root / DENYLIST_NAME).write_text(SELFTEST_SOURCE_SCAN_DENYLIST, encoding="utf-8")
         source_scan_status, source_scan_output = _capture_main(
-            ["--root", str(root), "--account-slug", "neutral-owner"]
+            ["--root", str(root), "--account-slug", "neutral-owner", "--no-registry"]
         )
         _selftest_check(
             source_scan_status == 0
@@ -1006,6 +1159,32 @@ def selftest_end_to_end():
         (root / "README.md").write_text(
             _fixture_module_line() + "\n",
             encoding="utf-8",
+        )
+        no_registry_status, no_registry_output = _capture_main(
+            ["--root", str(root), "--account-slug", "neutral-owner", "--no-registry"]
+        )
+        _selftest_check(
+            no_registry_status == 1
+            and "gate-error: registry/modules.json exists under --root but --no-registry was passed (fail-closed)"
+            in no_registry_output,
+            "conventional registry rejects explicit opt-out: %r" % no_registry_output,
+        )
+        conflicting_status, conflicting_output = _capture_main(
+            [
+                "--root",
+                str(root),
+                "--account-slug",
+                "neutral-owner",
+                "--registry",
+                "registry/modules.json",
+                "--no-registry",
+            ]
+        )
+        _selftest_check(
+            conflicting_status == 1
+            and "gate-error: --registry and --no-registry are mutually exclusive (fail-closed)"
+            in conflicting_output,
+            "registry flags are mutually exclusive: %r" % conflicting_output,
         )
         status, output = _capture_main(
             ["--root", str(root), "--account-slug", "neutral-owner", "--registry", "registry/modules.json"]
@@ -1047,7 +1226,7 @@ def selftest_end_to_end():
             ("README.md", DENYLIST_NAME, ".gitignore", "node_modules/x.md", "published.txt"),
         )
         status, output = _capture_main(
-            ["--root", str(root), "--account-slug", "neutral-owner"]
+            ["--root", str(root), "--account-slug", "neutral-owner", "--no-registry"]
         )
         _selftest_check(
             status == 1
@@ -1063,7 +1242,7 @@ def selftest_end_to_end():
         (root / "binary.dat").write_bytes(b"\x80\x81\x82")
         _initialize_git_fixture(root, ("README.md", DENYLIST_NAME, "binary.dat"))
         status, output = _capture_main(
-            ["--root", str(root), "--account-slug", "neutral-owner"]
+            ["--root", str(root), "--account-slug", "neutral-owner", "--no-registry"]
         )
         _selftest_check(
             status == 0
@@ -1078,7 +1257,7 @@ def selftest_end_to_end():
         os.symlink("https://github." "com/neutral-owner/private", root / "published-link")
         _initialize_git_fixture(root, ("README.md", DENYLIST_NAME, "published-link"))
         status, output = _capture_main(
-            ["--root", str(root), "--account-slug", "neutral-owner"]
+            ["--root", str(root), "--account-slug", "neutral-owner", "--no-registry"]
         )
         _selftest_check(
             status == 1
@@ -1095,7 +1274,7 @@ def selftest_end_to_end():
             "email-address\t\\b[A-Z0-9._%+\\-]+@[A-Z0-9.\\-]+\\.[A-Z]{2,}\\b\n",
         )
         status, output = _capture_main(
-            ["--root", str(root), "--account-slug", "neutral-owner"]
+            ["--root", str(root), "--account-slug", "neutral-owner", "--no-registry"]
         )
         _selftest_check(
             status == 1 and "denylist: README.md:1 contains email-address" in output,
@@ -1108,7 +1287,7 @@ def selftest_end_to_end():
             root, "See https://gist.github." "com/neutral-owner/example\n"
         )
         status, output = _capture_main(
-            ["--root", str(root), "--account-slug", "neutral-owner"]
+            ["--root", str(root), "--account-slug", "neutral-owner", "--no-registry"]
         )
         _selftest_check(
             status == 1 and "personal-url: README.md:1" in output,
@@ -1121,7 +1300,7 @@ def selftest_end_to_end():
         (root / "README.md").unlink()
         (root / "safe.txt").write_text("safe\n", encoding="utf-8")
         status, output = _capture_main(
-            ["--root", str(root), "--account-slug", "neutral-owner"]
+            ["--root", str(root), "--account-slug", "neutral-owner", "--no-registry"]
         )
         _selftest_check(
             status == 1 and "corpus-floor: README.md was not among scanned documents" in output,
@@ -1133,7 +1312,7 @@ def selftest_end_to_end():
         _materialize_fixture(root)
         (root / ".git").mkdir()
         status, output = _capture_main(
-            ["--root", str(root), "--account-slug", "neutral-owner"]
+            ["--root", str(root), "--account-slug", "neutral-owner", "--no-registry"]
         )
         _selftest_check(
             status == 1
@@ -1157,6 +1336,7 @@ def selftest_end_to_end():
                 "neutral-owner",
                 "--denylist",
                 "policies/secret-rules.txt",
+                "--no-registry",
             ]
         )
         _selftest_check(
@@ -1203,7 +1383,12 @@ def main(argv=None):
     parser.add_argument("--selftest", action="store_true", help="run embedded gate fixtures")
     parser.add_argument("--root", type=Path, default=Path("."), help="repository checkout to inspect (default: .)")
     parser.add_argument("--account-slug", default=None, help="personal account slug (required for normal runs)")
-    parser.add_argument("--registry", type=Path, default=None, help="optional publication registry JSON file")
+    parser.add_argument("--registry", type=Path, default=None, help="publication registry JSON file")
+    parser.add_argument(
+        "--no-registry",
+        action="store_true",
+        help="declare that this repository has no publication registry; required when --registry is omitted",
+    )
     parser.add_argument(
         "--denylist",
         type=Path,
@@ -1213,7 +1398,13 @@ def main(argv=None):
     args = parser.parse_args(argv)
     if args.selftest:
         return run_selftests()
-    return run_gate(args.root, args.account_slug, args.registry, args.denylist)
+    return run_gate(
+        args.root,
+        args.account_slug,
+        args.registry,
+        args.denylist,
+        no_registry=args.no_registry,
+    )
 
 
 if __name__ == "__main__":

--- a/templates/publication-gate/fixtures/sample.publication-denylist
+++ b/templates/publication-gate/fixtures/sample.publication-denylist
@@ -1,3 +1,5 @@
 # Copy this file to the repository root as .publication-denylist and customize it.
 private-marker	acme[-_ ]secret
 private-host	private\.example\.invalid
+# Keep local@host/... coverage in denylist territory.
+email-address	\b[A-Z0-9._%+\-]+@[A-Z0-9.\-]+\.[A-Z]{2,}\b


### PR DESCRIPTION
Closes #97
Closes #98

Fail-closed hardening of the shared publication-gate template (single-file checker that adopting repos copy byte-identically).

- **#97** — a file that fails UTF-8 decoding is red (`source-read: <path> is not valid UTF-8 text (fail-closed)`) unless its suffix is in an enumerated `BINARY_SUFFIXES` set, it is `.DS_Store`, or it is a `.plist` starting with the `bplist00` signature. Skipped binaries are listed by name under the unchanged `binary files skipped: N` line. Credential containers (`.key .p12 .pfx .der .jks .pem …`) are deliberately red.
- **#98-1** — omitting `--registry` is red unless the caller passes the explicit `--no-registry`. Both flags → red. `--no-registry` with `registry/modules.json` on disk, or with a non-empty `.publication-label-whitelist` → red. Skip notices print only under the explicit opt-out.
- **#98-2** — bare `@github.com/<slug>[/<repo>]` (and `-@` `.@` `+@` `%@` prefixed forms) are personal-url findings; `local@github.com/...` stays e-mail-rule territory and the shipped sample denylist now carries an `email-address` rule (README makes it a requirement). Nested personal URLs inside another URL's path/query/fragment (`foo.bar/github.com/<slug>/x`, `?u=github.com/<slug>`, `github.com\/<slug>\/x`, `?u=user@github.com/<slug>/x`, allowlisted-repo/private-repo concatenations) are all detected; the walk is marker-anchored (linear) and field-bounded, with a reference implementation asserted equal in the selftest.
- Embedded selftest: 69 → **143 assertions**. README: `--no-registry` contract, binary posture + recourse, nested-host reds + recourse, adopter re-copy delta list, 移行節 4 deltas.

Downstream re-copy (family-os / caty-ai/.github, pinned at 2d2d4b3) is a separate lane. Follow-ups filed from the panel's non-blocking nits: #150.

## Files touched (= WIP declaration incl. 2026-09-04 amendment, 3 files)

- `templates/publication-gate/check_publication_gate.py`
- `templates/publication-gate/README.md`
- `templates/publication-gate/fixtures/sample.publication-denylist`

`git diff --stat origin/main...6f96477` = exactly these 3 files (1092 insertions / 74 deletions, 7 commits). No undeclared files.

## 完了記録 (Completion record)

**候補 commit SHA: `6f96477`** (= PR head; `97ebf5b` implementation + `1abd787` `f5083c7` `fd34195` `ff6d7c9` `95e8e0c` panel deltas 1–5 reviewed to 5/5 GO + `6f96477` delta-6 = two README release literals only, see the L1-8 note comment)

implementer: Codex GPT-5.6 Sol (codex exec, default profile = sol, effort high; orchestrated by Alpha who wrote briefs, arbitrated, verified and committed)
reviewer: 異種5席 — Opus 5 / GLM 5.3 / Grok 4.6 / Kimi K3 / Codex GPT-5.6 Sol (fresh context, read-only; r1 blind; 5 rounds). Full record with requested/actual models and the correlated-seats exception: https://github.com/caty-ai/family-dev-handbook/pull/147#issuecomment-5531047875

### Done when → PASS/FAIL

**#97**
1. Template fails closed on decode errors for text files — **PASS**. Evidence (2026-09-04, `95e8e0c`, checker unchanged at `6f96477`): selftest `non-UTF-8 text suffix fails closed` / `non-UTF-8 extensionless file fails closed` / git-mode `notes.md` red; Alpha oracle `printf 'Shoji\n\xff\n' > secret.md` + sample denylist → `FAILED … source-read: secret.md is not valid UTF-8 text (fail-closed)`, EXIT=1 (was EXIT=0 with `binary files skipped: 1` on 2d2d4b3). Seat probes: Shift-JIS `.txt`, UTF-16 `.md`, `.csv`, `.env`, `.cs`, `.ipynb`, `.gltf`, `.key` all red; `.png`/`.icns`/binary plist skipped and listed.
2. Regression fixture embedded — **PASS**. Evidence: `python3 -B templates/publication-gate/check_publication_gate.py --selftest` → `PASS (publication gate selftest; assertions: 143)`; copied-alone probe inside the selftest passes.
3. README 移行節 updated — **PASS**. Evidence: 「移行時の意図的な差分は4つ」+ 2026-09 改訂 delta list (README.md).
4. Adopting repos notified to re-copy — **N/A in this PR (separate lane by owner instruction)**: family-os / caty-ai/.github re-copy lanes are opened after the release cut; README names the re-copy target (`v0.24.0`) and the caller change (`--no-registry`).

**#98**
1. Design decision recorded for `--registry` omission — **PASS**. Evidence: `--no-registry` explicit opt-out; selftests `registry omission fails closed without skip notices`, `registry flags are mutually exclusive`, `conventional registry rejects explicit no-registry opt-out`, `non-empty whitelist rejects explicit no-registry opt-out`; CLI no-flags run → `gate-error: --registry is required unless --no-registry is passed explicitly (fail-closed; registry-backed checks are never skipped silently)`, EXIT=1. README documents the contract and the conventional-path limit.
2. URL_CANDIDATE handles the empty-local-part `@host/...` shape — **PASS**. Evidence: selftests `bare-at personal repository URL` / `bare-at personal account profile` / `email-context personal URL remains denylist territory`; Alpha 18-string corpus old-vs-new: bare-@ repo/profile/case/`%40`-decoded/markdown-link all 0→1, zero old-only losses (re-run at every candidate).
3. Template version bump + adopters notified — **PASS (version) / N/A (notification, see #97-4)**. Evidence: release `v0.24.0` declared below; README 2026-09 改訂 section names it as the re-copy target.

### Review (L1-3 / L1-10 / L1-11)

Size M / 高リスク領域（公開前ゲート）→ 異種5席 by `loom-seats --size M --risk release-gate`. Round trail: r1 (3 NO-GO: Kimi CRITICAL nested-host regression, Codex CRITICAL suffix-allowlist fail-open convergent with 3 seats, Opus blocker README/sample e-mail gap) → delta-1/2 → r2 (3 NO-GO/2 GO-with-nits: backslash paths, first-hit-only walk, `+@`/`%@`, UTF-16 plist) → delta-3 → r3 (Codex CRITICAL query-field absorption; 4-seat quadratic) → delta-4 → r4 (**all 5 seats** independently found the anchored walk dropped userinfo/bare-@ nested spans) → delta-5 → r5: **5/5 cumulative GO** (Opus GO · Kimi GO · Codex GO · GLM GO-with-nits · Grok GO-with-nits; every remaining item is a selftest-quality or posture nit, filed as #150). Alpha arbitration recorded for one rejected finding (unrelated-host path reds kept as fail-closed) and accepted by all seats.

### CI state

Required checks at `6f96477`: test-lint (lint / test / test-macos) · gitleaks · history-check · risk-review-gate · repo-state — **all green**. Non-required advisory `pr-size / pr-size` is **red** (1166 lines > 250): the volume is the embedded selftest (143 assertions) and mechanical `--no-registry` additions to every existing e2e call; splitting #97/#98 would not bring either half under the limit. Requesting the owner's `size-exempt` label (T-4 exception: known, unrelated to correctness, advisory check).

### release

- **release: v0.24.0** — annotated tag on the merge commit + GitHub Release (release-sync carrier). Template behaviour changes → 出荷相当. README names `v0.24.0` as the adopter re-copy target (v0.22.0 / v0.23.0 were cut today by the #146 / #101 lanes; see the L1-8 note comment).
- **previous release: v0.23.0** — fulfilled (GitHub Release exists and is Latest: https://github.com/caty-ai/family-dev-handbook/releases/tag/v0.23.0, published 2026-09-03).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
