### PR TITLE
security(review-labels): risk path, status artifact, visibility label, base retarget (#121 #94 #142 #99)

### DIFF
--- a/.github/workflows/reusable-review-labels.yml
+++ b/.github/workflows/reusable-review-labels.yml
@@ -18,15 +18,15 @@
 # 設計姿勢 (handbook docs/05・docs/06・docs/09):
 # - 高リスク領域の定義の正本は handbook docs/06 (再定義しない)。本ファイルはパスへの写像だけを持つ。
 # - 承認は「貼り手」と「head SHA」の両方に束縛する。既定 = 方式1: ゲート自身のイベント判定 —
-#   作者が単独で起こせるイベント (synchronize / reopened / ready_for_review) の run では承認ラベルを
+#   作者が単独で起こせるイベント (edited / synchronize / reopened / ready_for_review) の run では承認ラベルを
 #   無効として赤にし、緑に戻せるのは triage 権限者しか起こせないイベント (labeled / unlabeled) だけにする。
 #   緑候補では方式2の貼り手条件 (b) (API 応答順でなく created_at 基準の最新 action が名簿内 actor の labeled で、後続 unlabeled なし) を完全に機械照合する。
 #   ラベルの機械剥がし (「剥がしは機械・貼るのは人間」) は
 #   可視化のための衛生で、判定はその成否に依存しない。
 # - 確認者名簿は base (main) 側の .github/risk-reviewers.txt から読む。PR head から読んではならない —
 #   「PR が名簿に自分を足して自分で通す」循環が開く。名簿不在・空・プレースホルダ = 赤。
-# - ゲート判定は read 権限で完結し fork でも必ず赤/緑を出す。ラベル付与・剥がしの書き込みは
-#   fork では 403 になるため警告に留める (fail-open・ゲート判定には影響させない)。
+# - ゲート判定は read 権限で完結し fork でも必ず赤/緑を出す。fork のラベル取得失敗・ラベル不在・
+#   書き込み失敗は警告、same-repo のラベル取得失敗・ラベル不在・書き込み失敗は赤。visibility-only でゲート判定には影響しない。
 # - pull_request_target は使わない (untrusted コードに write トークンを渡す典型的脆弱形)。
 # - risk_paths_* 入力は宣言必須・fail-closed のカテゴリ入力であって pr-size の exclude_patterns
 #   とは性質が違う: review-labels は security gate なので、caller が __DECLARE_ME__ のまま渡す
@@ -329,11 +329,16 @@ jobs:
             write_action_required "Risk detection failed" "detect-risk-paths job result '${DETECT_RESULT}'; high-risk paths could not be judged; failing closed." "Fix the risk path declarations in the caller with: block, then re-run the workflow."
             exit 1
           fi
-          if [ "$RISK_HIT" != "true" ]; then
+          if [ "$RISK_HIT" = "false" ]; then
             echo "::notice::no high-risk paths touched — gate green."
             # 高リスク変更が無くても check は常に走って明示的な緑を出す (skipped の意味論に頼らない)。
             echo 'review_status=[]' > review-status.json
             exit 0
+          fi
+          if [ "$RISK_HIT" != "true" ]; then
+            echo "::error::risk_hit='${RISK_HIT}' is neither true nor false — cannot judge, failing closed (FP-6)."
+            write_action_required "Risk detection output invalid" "detect-risk-paths reported success but risk_hit='${RISK_HIT}' is neither true nor false; cannot judge, failing closed (FP-6)." "Open the detect-risk-paths job log; re-run the workflow."
+            exit 1
           fi
 
           # 確認者名簿: base (main) 側から読む。PR head から読まない (自己承認の循環封じ)。
@@ -354,28 +359,27 @@ jobs:
           fi
 
           # 承認の head SHA 束縛はイベント種別で行う (剥がしジョブの成功に依存しない):
-          # synchronize (新 push)・reopened (閉鎖中の push を挟みうる)・ready_for_review (draft⇄ready の
-          # 往復は PR 作者が単独で起こせる) では、承認ラベルの有無にかかわらず赤 — 「新しい head /
-          # 作者起点の再評価は未承認」。承認がラベル現在値で再評価されるのは labeled / unlabeled の run
-          # (どちらも triage 権限者にしか起こせない) に限られる。ラベル剥がし (書き込み) が 403 になる
-          # fork PR でも、作者単独の承認持ち回しは成立しない。
-          # base retarget も judged diff を差し替える: risky change 済み staging へ PR を開いて空 diff を緑にし、
-          # main へ付け替えると stale green を持ち回せる。caller が edited を購読した時だけここで再評価する (#99)。
-          if [ "$EVENT_ACTION" = "edited" ] && [ -n "$BASE_CHANGED_FROM" ]; then
-            echo "::error::base branch retargeted from '${BASE_CHANGED_FROM}' to '${BASE_REF}' (event: edited) — the judged diff changed; any previous risk-reviewed approval is void for this head"
-            echo ""
-            echo "touched high-risk files:"
-            printf '%s\n' "$RISK_FILES" | sed 's/^/  - /'
-            write_action_required "Risk re-review required" "The base branch was retargeted from '${BASE_CHANGED_FROM}' to '${BASE_REF}'; the judged diff changed and previous approval is void for this head." "Ask an owner listed in .github/risk-reviewers.txt to review the retargeted diff and re-apply the risk-reviewed label."
-            exit 1
-          fi
-          if [ "$EVENT_ACTION" = "synchronize" ] || [ "$EVENT_ACTION" = "reopened" ] || [ "$EVENT_ACTION" = "ready_for_review" ]; then
-            echo "::error::new head SHA (event: ${EVENT_ACTION}) — any previous risk-reviewed approval is void for this head. A human on the roster must re-review the diff and re-apply the label."
-            echo ""
-            echo "touched high-risk files:"
-            printf '%s\n' "$RISK_FILES" | sed 's/^/  - /'
-            STATUS='[{"source":"risk review","results":[{"kind":"action_required","title":"Risk re-review required","summary":"The head changed; previous approval is void. Re-apply risk-reviewed for this head SHA.","detail":"","how_to_fix":"Ask an owner listed in .github/risk-reviewers.txt to review the new diff and re-apply the risk-reviewed label."}]}]'
-            echo "review_status=${STATUS}" > review-status.json
+          # edited (title/body edit・base retarget)・synchronize (新 push)・reopened (閉鎖中の push を挟みうる)・
+          # ready_for_review (draft⇄ready の往復) はすべて PR 作者が単独で起こせるため、承認ラベルの
+          # 有無にかかわらず赤 — 「新しい head / 作者起点の再評価は未承認」。承認がラベル現在値で
+          # 再評価されるのは labeled / unlabeled の run (どちらも triage 権限者にしか起こせない) に
+          # 限られる。ラベル剥がし (書き込み) が 403 になる fork PR でも、作者単独の承認持ち回しは
+          # 成立しない。edited を購読していない caller はこの分岐を起動しないため従来どおり動く (#99)。
+          if [ "$EVENT_ACTION" = "edited" ] || [ "$EVENT_ACTION" = "synchronize" ] || [ "$EVENT_ACTION" = "reopened" ] || [ "$EVENT_ACTION" = "ready_for_review" ]; then
+            if [ "$EVENT_ACTION" = "edited" ] && [ -n "$BASE_CHANGED_FROM" ]; then
+              echo "::error::base branch retargeted from '${BASE_CHANGED_FROM}' to '${BASE_REF}' (event: edited) — the judged diff changed; any previous risk-reviewed approval is void for this head"
+              echo ""
+              echo "touched high-risk files:"
+              printf '%s\n' "$RISK_FILES" | sed 's/^/  - /'
+              write_action_required "Risk re-review required" "The base branch was retargeted from '${BASE_CHANGED_FROM}' to '${BASE_REF}'; the judged diff changed and previous approval is void for this head." "Ask an owner listed in .github/risk-reviewers.txt to review the retargeted diff and re-apply the risk-reviewed label."
+            else
+              echo "::error::new head SHA (event: ${EVENT_ACTION}) or author-editable PR metadata (edited) — any previous risk-reviewed approval is void for this head. A human on the roster must re-review the diff and re-apply the label."
+              echo ""
+              echo "touched high-risk files:"
+              printf '%s\n' "$RISK_FILES" | sed 's/^/  - /'
+              STATUS='[{"source":"risk review","results":[{"kind":"action_required","title":"Risk re-review required","summary":"The head changed; previous approval is void. Re-apply risk-reviewed for this head SHA.","detail":"","how_to_fix":"Ask an owner listed in .github/risk-reviewers.txt to review the new diff and re-apply the risk-reviewed label."}]}]'
+              echo "review_status=${STATUS}" > review-status.json
+            fi
             exit 1
           fi
 
@@ -455,7 +459,7 @@ jobs:
               exit 1
             fi
             echo "::notice::risk-reviewed label present — gate green."
-            echo "audit: approval is bound to the current head SHA at the gate itself (synchronize/reopened runs go red regardless of the label); the strip job additionally removes the stale label for visibility."
+            echo "audit: approval is bound to the current head SHA at the gate itself (edited/synchronize/reopened/ready_for_review runs go red regardless of the label); the strip job additionally removes the stale label for visibility."
             printf '%s\n' "audit: risk-reviewed applied by '${ACTOR}' — verified against the base-side roster."
             echo "audit: roster (origin/${BASE_REF}:.github/risk-reviewers.txt):"
             printf '%s\n' "$ROSTER" | sed 's/^/  - /'
@@ -479,7 +483,7 @@ jobs:
           # ── 方式2との hybrid ──────────────────────────────────────────
           # (a) は方式1のラベル現在有無、(b) は created_at 基準の最新 risk-reviewed event が
           # 名簿内 actor の labeled であること (後続 unlabeled なしを含む) まで完全実装済み。
-          # (c) labeled-after-push 時刻照合は意図的に未実装。synchronize / reopened / ready_for_review は
+          # (c) labeled-after-push 時刻照合は意図的に未実装。edited / synchronize / reopened / ready_for_review は
           # イベント束縛で扱う一方、fork 403 で剥がせない古いラベルの既知残余は templates/ci/README.md に記載する。
 
       - name: Upload review status artifact
@@ -494,7 +498,7 @@ jobs:
           if-no-files-found: warn
 
   # ── 書き込み系 (可視化): 可視化ラベルの付与と、head/diff 変更時の機械剥がし ─────────
-  # fork 403 は警告、ラベル不在・same-repo 書込失敗は赤。visibility-only でゲート判定には影響しない。
+  # fork の取得失敗・ラベル不在・書込失敗は警告、same-repo の取得失敗・ラベル不在・書込失敗は赤。visibility-only でゲート判定には影響しない。
   labels:
     name: apply-visibility-labels
     needs: detect
@@ -512,9 +516,9 @@ jobs:
             exit 1
           fi
 
-      # 新 push に加え base retarget でも judged diff が変わるため、古い承認を可視化上も剥がす (#99)。
-      - name: Strip approval labels on new push (剥がしは機械・貼るのは人間)
-        if: github.event.action == 'synchronize' || (github.event.action == 'edited' && github.event.changes.base.ref.from != '')
+      # edited は title/body edit と base retarget の両方を含む。新 push / edit 後の古い承認を可視化上も剥がす (#99)。
+      - name: Strip approval labels on new push / edit (剥がしは機械・貼るのは人間)
+        if: github.event.action == 'synchronize' || github.event.action == 'edited'
         continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -526,7 +530,7 @@ jobs:
             echo "::warning::label fetch failed — skipping strip (hygiene only; gate judgment is unaffected)."; exit 0; }
           if grep -Fxq 'risk-reviewed' <<<"$LABELS"; then
             gh pr edit "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --remove-label 'risk-reviewed' \
-              || echo "::warning::could not remove risk-reviewed (fork PR has no write token — 403 is expected there)."
+              || echo "::warning::could not remove risk-reviewed — write failure on a fork PR (403 expected — any write failure on a fork is treated as the no-token case)."
             echo "risk-reviewed removed: approval is bound to the head SHA the owner saw; a new push requires re-review."
           fi
 
@@ -539,17 +543,25 @@ jobs:
         run: |
           set -euo pipefail
           LABEL_NAMES=$(gh api --paginate "repos/${GITHUB_REPOSITORY}/labels?per_page=100" --jq '.[].name') || {
+            if [ "$HEAD_REPO" != "$GITHUB_REPOSITORY" ]; then
+              echo "::warning::label list fetch failed for 'needs-risk-review' in ${GITHUB_REPOSITORY}; a fork contributor cannot fix repository labels, so continuing without the visibility label. Gate evaluation is unaffected."
+              exit 0
+            fi
             echo "::error::label list fetch failed — cannot verify that 'needs-risk-review' exists in ${GITHUB_REPOSITORY}; failing red (visibility job only — gate judgment is unaffected)"
             exit 1
           }
           if ! grep -Fxq 'needs-risk-review' <<<"$LABEL_NAMES"; then
+            if [ "$HEAD_REPO" != "$GITHUB_REPOSITORY" ]; then
+              echo "::warning::label 'needs-risk-review' is missing in ${GITHUB_REPOSITORY}; a fork contributor cannot fix repository labels, so continuing without the visibility label. Gate evaluation is unaffected."
+              exit 0
+            fi
             echo "::error::label 'needs-risk-review' is missing in ${GITHUB_REPOSITORY}; create it per templates/ci/README.md step 3: gh label create needs-risk-review --color D93F0B --description \"高リスク領域に触れた PR (機械が自動付与)\""
             exit 1
           fi
           if ! ERR=$(gh pr edit "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --add-label 'needs-risk-review' 2>&1); then
             printf '%s\n' "$ERR"
             if [ "$HEAD_REPO" != "$GITHUB_REPOSITORY" ]; then
-              echo "::warning::could not add needs-risk-review on a fork PR (no write token — 403 is expected there). Gate evaluation is unaffected."
+              echo "::warning::could not add needs-risk-review: write failure on a fork PR (403 expected — any write failure on a fork is treated as the no-token case). Gate evaluation is unaffected."
               exit 0
             fi
             echo "::error::could not add needs-risk-review on a same-repo PR — this is not the fork 403 case; failing red so the missing visibility label is not silently absent. Gate evaluation is unaffected."

--- a/.github/workflows/reusable-review-labels.yml
+++ b/.github/workflows/reusable-review-labels.yml
@@ -498,7 +498,8 @@ jobs:
           if-no-files-found: warn
 
   # ── 書き込み系 (可視化): 可視化ラベルの付与と、head/diff 変更時の機械剥がし ─────────
-  # fork の取得失敗・ラベル不在・書込失敗は警告、same-repo の取得失敗・ラベル不在・書込失敗は赤。visibility-only でゲート判定には影響しない。
+  # apply step: fork の取得失敗・ラベル不在・書込失敗は警告、same-repo の同失敗は赤。strip step は衛生専用で
+  # 失敗は fork/same-repo とも警告 (ゲートのイベント束縛が承認無効化の正本)。visibility-only でゲート判定には影響しない。
   labels:
     name: apply-visibility-labels
     needs: detect
@@ -529,9 +530,11 @@ jobs:
           LABELS=$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json labels --jq '.labels[].name') || {
             echo "::warning::label fetch failed — skipping strip (hygiene only; gate judgment is unaffected)."; exit 0; }
           if grep -Fxq 'risk-reviewed' <<<"$LABELS"; then
-            gh pr edit "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --remove-label 'risk-reviewed' \
-              || echo "::warning::could not remove risk-reviewed — write failure on a fork PR (403 expected — any write failure on a fork is treated as the no-token case)."
-            echo "risk-reviewed removed: approval is bound to the head SHA the owner saw; a new push requires re-review."
+            if gh pr edit "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --remove-label 'risk-reviewed'; then
+              echo "risk-reviewed removed: approval is bound to the head SHA the owner saw; a new push / edit requires re-review."
+            else
+              echo "::warning::could not remove risk-reviewed (hygiene only — a fork PR has no write token, and the gate voids the approval on this event regardless). Gate judgment is unaffected."
+            fi
           fi
 
       - name: Apply needs-risk-review label (可視化専用・判定に影響しない)

--- a/.github/workflows/reusable-review-labels.yml
+++ b/.github/workflows/reusable-review-labels.yml
@@ -4,6 +4,7 @@
 #   emit_review_status.py 依存を外しインライン生成に統一・ラベル語彙と承認判定を家庭版に翻案。
 #   2026-08-19: handbook#80 で workflow_call の reusable 正本へ再変換 (pull_request → workflow_call)。
 #   高リスクパスのカテゴリ宣言 (RISK_PATHS_BILLING/OUTBOUND/GATES/AUTH) を caller の with: 入力へ移動。
+#   2026-09-04: #121/#94/#142/#99 — risk path・status artifact・visibility label・base retarget を harden。
 #
 # 守るもの: 高リスク領域 (enforcement/権限境界・認証・課金・不可逆操作・対外送信) に触れる PR が、
 #           人間 (オーナー) の確認ラベルなしに merge されないこと。検知は機械・判定は人間。
@@ -98,10 +99,14 @@ jobs:
           # 高リスク領域のパス写像 (定義の正本は handbook docs/06 — ここは写像だけ)。
           # パターンは git pathspec :(glob) 意味論・大文字小文字非依存で照合する
           # (名前でなく本質でマッチさせる — Migrations/ を取り逃さない)。
+          # release-sync-ignore は tag ごとの T-5 履行要否を決める。reusable-release-sync.yml と
+          # check-release-drift.sh は default branch から読み tagged commit の自己免除を防ぐが、
+          # 免除追加 PR 自体も risk-reviewers.txt と同形で人間確認が必要 (#121)。
           RISK_PATHS_DEFAULT='
             .github/workflows/**
             .github/actions/**
             .github/risk-reviewers.txt
+            .github/release-sync-ignore
             .gitleaks.toml
             gitleaks.toml
             .gitleaksignore
@@ -211,6 +216,9 @@ jobs:
           # 1ファイルにも解決しない場合、リネーム・配置変更で写像が乖離した兆候 — 「存在しない
           # 敵を守れているように見える」まさに #31 の形。ログの警告で人間の判断に回す。
           # 展開手順の機械確認にはこのログの ::warning:: 確認を含める (README 手順 6)。
+          # liveness は RISK_PATHS_REPO だけを調べ、DEFAULT は汎用網なので意図的に調べない。
+          # そのため DEFAULT が覆わない新しい設定ファイルや別綴りの migrations dir は警告にならず、
+          # リポ固有宣言で補う必要がある (#99 の記録済み制約)。
           while IFS= read -r pat; do
             pat="$(echo "$pat" | sed 's/^[[:space:]]*//; s/[[:space:]]*$//')"
             [ -n "$pat" ] || continue
@@ -284,6 +292,7 @@ jobs:
           set -euo pipefail
           if [ "${{ github.event_name }}" != "pull_request" ]; then
             echo "::error::reusable gates must be called from a pull_request caller — this reusable's range logic depends on the PR event payload (fail-closed, FP-6). event was: ${{ github.event_name }}"
+            # PR が無ければ Layer-2 コメント先も無いため、この pre-checkout の赤だけ artifact 対象外 (#142)。
             exit 1
           fi
 
@@ -301,13 +310,23 @@ jobs:
           LC_ALL: C.UTF-8
           DETECT_RESULT: ${{ needs.detect.result }}
           EVENT_ACTION: ${{ github.event.action }}
+          BASE_CHANGED_FROM: ${{ github.event.changes.base.ref.from || '' }}
           RISK_HIT: ${{ needs.detect.outputs.risk_hit }}
           RISK_FILES: ${{ needs.detect.outputs.risk_files }}
         run: |
           set -euo pipefail
+          # 赤で終わる経路は必ず review_status を残す (#142): Layer-2 合成器が「該当なし」と誤読しない。
+          write_action_required() {  # title summary how_to_fix — JSON は jq で組む (引用の安全)
+            STATUS=$(jq -cn --arg t "$1" --arg s "$2" --arg h "$3" \
+              '[{"source":"risk review","results":[{"kind":"action_required","title":$t,"summary":$s,"detail":"","how_to_fix":$h}]}]')
+            echo "review_status=${STATUS}" > review-status.json
+          }
+          rm -f review-status.json
+          trap 'rc=$?; if [ "$rc" -ne 0 ] && [ ! -s review-status.json ]; then write_action_required "Risk review gate error" "The risk-review gate exited unexpectedly (exit ${rc}) before reaching a decision; treat this head as unreviewed." "Open the risk-review-gate job log, fix the cause, and re-run; a human on .github/risk-reviewers.txt must still apply risk-reviewed for this head SHA."; fi' EXIT
           # detect が success 以外 (宣言忘れの赤・範囲解決失敗・キャンセル) なら本ジョブも赤 (fail-closed)。
           if [ "$DETECT_RESULT" != "success" ]; then
             echo "::error::detect job result is '${DETECT_RESULT}' — cannot judge risk paths, failing closed. See the detect-risk-paths job log (undeclared RISK_PATHS_REPO placeholder, unresolved diff range, etc.)."
+            write_action_required "Risk detection failed" "detect-risk-paths job result '${DETECT_RESULT}'; high-risk paths could not be judged; failing closed." "Fix the risk path declarations in the caller with: block, then re-run the workflow."
             exit 1
           fi
           if [ "$RISK_HIT" != "true" ]; then
@@ -319,13 +338,19 @@ jobs:
 
           # 確認者名簿: base (main) 側から読む。PR head から読まない (自己承認の循環封じ)。
           ROSTER=$(git show "origin/${BASE_REF}:.github/risk-reviewers.txt" 2>/dev/null) || {
-            echo "::error::.github/risk-reviewers.txt not found on origin/${BASE_REF} — roster missing, failing closed. Copy templates/ci/risk-reviewers.txt.example and commit it on main."; exit 1; }
+            echo "::error::.github/risk-reviewers.txt not found on origin/${BASE_REF} — roster missing, failing closed. Copy templates/ci/risk-reviewers.txt.example and commit it on main."
+            write_action_required "Risk reviewer roster missing" ".github/risk-reviewers.txt is missing on the base branch origin/${BASE_REF}; risk reviewer authorization cannot be judged." "Copy templates/ci/risk-reviewers.txt.example, add the authorized reviewers, and commit it on main."
+            exit 1; }
           ROSTER=$(printf '%s\n' "$ROSTER" | sed 's/#.*//' | sed 's/[[:space:]]//g' | sed '/^$/d')
           if [ -z "$ROSTER" ]; then
-            echo "::error::risk reviewer roster is empty — failing closed."; exit 1;
+            echo "::error::risk reviewer roster is empty — failing closed."
+            write_action_required "Risk reviewer roster empty" ".github/risk-reviewers.txt on the base branch contains no authorized reviewers; failing closed." "Copy templates/ci/risk-reviewers.txt.example, add the authorized reviewers, and commit it on main."
+            exit 1
           fi
           if grep -Fxq 'REPLACE_ME' <<<"$ROSTER"; then
-            echo "::error::risk reviewer roster still contains the REPLACE_ME placeholder — failing closed."; exit 1;
+            echo "::error::risk reviewer roster still contains the REPLACE_ME placeholder — failing closed."
+            write_action_required "Risk reviewer roster placeholder" ".github/risk-reviewers.txt on the base branch still contains REPLACE_ME; reviewer authorization is not configured." "Replace REPLACE_ME with authorized GitHub logins and commit the roster on main."
+            exit 1
           fi
 
           # 承認の head SHA 束縛はイベント種別で行う (剥がしジョブの成功に依存しない):
@@ -334,6 +359,16 @@ jobs:
           # 作者起点の再評価は未承認」。承認がラベル現在値で再評価されるのは labeled / unlabeled の run
           # (どちらも triage 権限者にしか起こせない) に限られる。ラベル剥がし (書き込み) が 403 になる
           # fork PR でも、作者単独の承認持ち回しは成立しない。
+          # base retarget も judged diff を差し替える: risky change 済み staging へ PR を開いて空 diff を緑にし、
+          # main へ付け替えると stale green を持ち回せる。caller が edited を購読した時だけここで再評価する (#99)。
+          if [ "$EVENT_ACTION" = "edited" ] && [ -n "$BASE_CHANGED_FROM" ]; then
+            echo "::error::base branch retargeted from '${BASE_CHANGED_FROM}' to '${BASE_REF}' (event: edited) — the judged diff changed; any previous risk-reviewed approval is void for this head"
+            echo ""
+            echo "touched high-risk files:"
+            printf '%s\n' "$RISK_FILES" | sed 's/^/  - /'
+            write_action_required "Risk re-review required" "The base branch was retargeted from '${BASE_CHANGED_FROM}' to '${BASE_REF}'; the judged diff changed and previous approval is void for this head." "Ask an owner listed in .github/risk-reviewers.txt to review the retargeted diff and re-apply the risk-reviewed label."
+            exit 1
+          fi
           if [ "$EVENT_ACTION" = "synchronize" ] || [ "$EVENT_ACTION" = "reopened" ] || [ "$EVENT_ACTION" = "ready_for_review" ]; then
             echo "::error::new head SHA (event: ${EVENT_ACTION}) — any previous risk-reviewed approval is void for this head. A human on the roster must re-review the diff and re-apply the label."
             echo ""
@@ -346,7 +381,9 @@ jobs:
 
           # ラベル取得の失敗・空応答は赤 (FP-6: 判定不能 = 赤)。
           LABELS=$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json labels --jq '.labels[].name') || {
-            echo "::error::label fetch failed — cannot judge, failing closed (FP-6)."; exit 1; }
+            echo "::error::label fetch failed — cannot judge, failing closed (FP-6)."
+            write_action_required "Risk review label fetch failed" "The risk review label state could not be fetched; failing closed." "Open the risk-review-gate job log, fix the GitHub API failure, and re-run."
+            exit 1; }
 
           # 方式1 (既定): risk-reviewed の現在有無で判定する (上のイベント束縛と対で機能する)。
           if grep -Fxq 'risk-reviewed' <<<"$LABELS"; then
@@ -454,10 +491,10 @@ jobs:
           path: review-status.json
           retention-days: 1
           overwrite: true
-          if-no-files-found: ignore
+          if-no-files-found: warn
 
-  # ── 書き込み系 (fail-open): 可視化ラベルの付与と、push 時の機械剥がし ─────────────
-  # fork PR では 403 になるため警告に留める。ゲート判定はこのジョブの成否に依存しない。
+  # ── 書き込み系 (可視化): 可視化ラベルの付与と、head/diff 変更時の機械剥がし ─────────
+  # fork 403 は警告、ラベル不在・same-repo 書込失敗は赤。visibility-only でゲート判定には影響しない。
   labels:
     name: apply-visibility-labels
     needs: detect
@@ -475,8 +512,9 @@ jobs:
             exit 1
           fi
 
+      # 新 push に加え base retarget でも judged diff が変わるため、古い承認を可視化上も剥がす (#99)。
       - name: Strip approval labels on new push (剥がしは機械・貼るのは人間)
-        if: github.event.action == 'synchronize'
+        if: github.event.action == 'synchronize' || (github.event.action == 'edited' && github.event.changes.base.ref.from != '')
         continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -494,11 +532,27 @@ jobs:
 
       - name: Apply needs-risk-review label (可視化専用・判定に影響しない)
         if: needs.detect.outputs.risk_hit == 'true'
-        continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
         run: |
           set -euo pipefail
-          gh pr edit "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --add-label 'needs-risk-review' \
-            || echo "::warning::could not add needs-risk-review (fork PR has no write token — 403 is expected there). Gate evaluation is unaffected."
+          LABEL_NAMES=$(gh api --paginate "repos/${GITHUB_REPOSITORY}/labels?per_page=100" --jq '.[].name') || {
+            echo "::error::label list fetch failed — cannot verify that 'needs-risk-review' exists in ${GITHUB_REPOSITORY}; failing red (visibility job only — gate judgment is unaffected)"
+            exit 1
+          }
+          if ! grep -Fxq 'needs-risk-review' <<<"$LABEL_NAMES"; then
+            echo "::error::label 'needs-risk-review' is missing in ${GITHUB_REPOSITORY}; create it per templates/ci/README.md step 3: gh label create needs-risk-review --color D93F0B --description \"高リスク領域に触れた PR (機械が自動付与)\""
+            exit 1
+          fi
+          if ! ERR=$(gh pr edit "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --add-label 'needs-risk-review' 2>&1); then
+            printf '%s\n' "$ERR"
+            if [ "$HEAD_REPO" != "$GITHUB_REPOSITORY" ]; then
+              echo "::warning::could not add needs-risk-review on a fork PR (no write token — 403 is expected there). Gate evaluation is unaffected."
+              exit 0
+            fi
+            echo "::error::could not add needs-risk-review on a same-repo PR — this is not the fork 403 case; failing red so the missing visibility label is not silently absent. Gate evaluation is unaffected."
+            exit 1
+          fi
+          echo "::notice::needs-risk-review label attached to PR #${PR_NUMBER}."

--- a/.github/workflows/review-labels.yml
+++ b/.github/workflows/review-labels.yml
@@ -8,7 +8,8 @@ on:
   pull_request:
     # 既定 types に labeled/unlabeled は含まれない。省くと「人間が承認しても再評価されない」
     # 「剥がしても緑が残る」の両不具合になるため明示する。
-    types: [opened, synchronize, reopened, labeled, unlabeled, ready_for_review]
+    # edited = base retarget 時に judged diff を再評価する (#99)。
+    types: [opened, synchronize, reopened, edited, labeled, unlabeled, ready_for_review]
 
 permissions:
   contents: read

--- a/.github/workflows/review-labels.yml
+++ b/.github/workflows/review-labels.yml
@@ -8,7 +8,7 @@ on:
   pull_request:
     # 既定 types に labeled/unlabeled は含まれない。省くと「人間が承認しても再評価されない」
     # 「剥がしても緑が残る」の両不具合になるため明示する。
-    # edited = base retarget 時に judged diff を再評価する (#99)。
+    # edited = title/body 編集・base retarget を作者起点イベントとして承認無効化の対象にする (#99)。
     types: [opened, synchronize, reopened, edited, labeled, unlabeled, ready_for_review]
 
 permissions:

--- a/templates/ci/README.md
+++ b/templates/ci/README.md
@@ -131,7 +131,7 @@ hardening として強く推奨する。
 - **ワークフロー自身の改変は機械的には止められない** — `pull_request` トリガは PR head 側のワークフロー定義（caller の `with:` 入力・呼び出し先タグを含む）で実行されるため、門番を無力化する PR はその無力化された門番で判定される（循環）。防御は PR timeline の監査＋可能なら `.github/workflows/` への CODEOWNERS 必須化。これがこのゲートを「可視化+監査」装置と位置づける理由の一つ
 - **`pr-size.yml` と `review-labels.yml` の caller types は削らない** — `labeled` / `unlabeled` / `ready_for_review` と `edited`（pr-size も購読）が無いと緑が古く残る。review-labels では `edited`（title/body edit・base retarget）も synchronize と同様に承認を無効化するため、作者側の PR metadata edit 後はオーナーが `risk-reviewed` を再適用する。`@ci-v1` pin 済みでも `edited` 未追加の caller はこの変更の影響を受けず従来どおり動くため、追随を推奨する (#99)
 - **死にパターン liveness はリポ固有宣言だけ** — `RISK_PATHS_REPO` のみを調べ、汎用網の DEFAULT は意図的に検査しない。網外の新規設定ファイルや別綴りの migrations dir は警告されないため、リポ宣言で補う (#99)
-- **可視化ラベルの失敗分類** — same-repo のラベル一覧取得失敗・`needs-risk-review` 不在・書き込み失敗は赤。fork のラベル一覧取得失敗・ラベル不在・書き込み失敗は、contributor がリポ設定を直せないため警告。`apply-visibility-labels` は visibility-only でゲート判定には影響しない (#94)
+- **可視化ラベルの失敗分類** — same-repo のラベル一覧取得失敗・`needs-risk-review` 不在・書き込み失敗は赤。fork のラベル一覧取得失敗・ラベル不在・書き込み失敗は、contributor がリポ設定を直せないため警告。剥がし（strip）step は衛生専用で失敗は常に警告（承認の無効化はゲートのイベント束縛が担う）。`apply-visibility-labels` は visibility-only でゲート判定には影響しない (#94)
 - **gate の赤は review_status を残す** — `Evaluate gate` step 内の全赤経路（明示的な script exit と EXIT trap が捕捉する予期しない error）で artifact を書く。対象外は、PR が無くコメント先も無い pre-checkout の non-`pull_request` event の赤と、script の前後で起きる infrastructure failure（actions/checkout failure・runner/cancellation kill）であり、これらは artifact を upload せず `if-no-files-found: warn` の warning として現れる (#142)
 
 ## Layer 2（合成器）の配線スケッチ

--- a/templates/ci/README.md
+++ b/templates/ci/README.md
@@ -34,6 +34,7 @@
    gh label create risk-reviewed    --color 0E8A16 --description "オーナー確認済み (人間のみが貼る・push で自動剥がし)"
    gh label create size-exempt     --color FBCA04 --description "サイズ上限の免除 (オーナーのみが貼る・push で自動剥がし)"
    ```
+   この変更以降、`needs-risk-review` が無い場合は `apply-visibility-labels` が silent no-op でなく赤になる (#94)。
 4. 各キャリアーの `with:` ブロックを必要に応じて埋める（stencil 自体は薄く保ち、説明はここに集約する）:
    - `test-lint.yml` — `run_macos` / `macos_skip_reason`（macOS 分を落とすなら理由をセットで明示。空または空白だけだと赤）/ `require_suite_reconciliation`（既定 `false`。照合行は T-6（handbook#81）の3値形式 `suites: declared=N executed=M skipped=K` のみ。行が無い場合は `::notice::` を出して通し、`true` のときは行が無いだけで赤。行がある場合は `executed + skipped != declared`・`executed == 0`・skip 率超過（`skipped×100 > declared×max_skip_percent`）のいずれも常に赤）/ `max_skip_percent`（skip 率上限・既定 `'20'`・整数のみ。値の変更は T-6 の記録規律に従う。テスト/lint コマンド自体は reusable 側が Makefile の `test`/`lint` ターゲットを試す）
    - `pr-size.yml` — `max_lines` / `exclude_patterns`（サイズ計測の除外パターン。既定の除外〔lockfile・`i18n/**`〕は reusable 側に内蔵済み）
@@ -80,6 +81,7 @@ advance 済みであることを先に確認してから**、`templates/ci/relea
 **免除する tag の正確な名前を1行に1つ**、`#` で始まる行はコメント、空行は無視、glob は不可。
 ファイルが無ければ空リストとして扱い、default branch から読めない場合は赤になる。移動する major
 tag 等、明示的に Release を作らない tag だけを列挙し、legacy lightweight tag は免除に入れない。
+`.github/release-sync-ignore` は既定の高リスクパスであり、触れる PR には `risk-reviewed` が必要になる (#121)。
 
 これは family の CI キャリアーで初めて `contents: write` を要求する門番であり、moving tag の
 `ci-v1` が初めて書き込み経路を守る。reusable は checkout せず、tag 側のリポ内容を実行せず、
@@ -127,7 +129,10 @@ hardening として強く推奨する。
 - **gitleaks の赤を消しても秘密は無効化されない** — 一度 push した秘密は必ず rotate する。本線は commit 前のローカル hook・CI は最後の網。検知の許容（allowlist）は base 側 `.gitleaks.toml` だけが効く — PR 側の設定・`.gitleaksignore`・inline `gitleaks:allow` は無効化してある（自己緩和封じ）
 - **承認後の push で承認が無効になるのは仕様** — 承認（`risk-reviewed` / `size-exempt`）は「オーナーが見た head SHA」に束縛される。無効化はゲート自身のイベント判定で行われ、ラベル剥がしジョブは可視化のための衛生（「剥がしは機械・貼るのは人間」）
 - **ワークフロー自身の改変は機械的には止められない** — `pull_request` トリガは PR head 側のワークフロー定義（caller の `with:` 入力・呼び出し先タグを含む）で実行されるため、門番を無力化する PR はその無力化された門番で判定される（循環）。防御は PR timeline の監査＋可能なら `.github/workflows/` への CODEOWNERS 必須化。これがこのゲートを「可視化+監査」装置と位置づける理由の一つ
-- **`pr-size.yml` と `review-labels.yml` の caller types は削らない** — `labeled` / `unlabeled` / `ready_for_review`（`pr-size` は `edited` も）が無いと、免除や承認の付与・剥奪や PR 本文更新で再評価されず、緑が古く残る
+- **`pr-size.yml` と `review-labels.yml` の caller types は削らない** — `labeled` / `unlabeled` / `ready_for_review` と `edited`（review-labels は base retarget の再評価）が無いと緑が古く残る。`@ci-v1` pin 済みでも `edited` 未追加の caller は従来どおり retarget 防御なしで動くため、追随を推奨するが互換性には影響しない (#99)
+- **死にパターン liveness はリポ固有宣言だけ** — `RISK_PATHS_REPO` のみを調べ、汎用網の DEFAULT は意図的に検査しない。網外の新規設定ファイルや別綴りの migrations dir は警告されないため、リポ宣言で補う (#99)
+- **可視化ラベルの失敗分類** — `needs-risk-review` 不在と same-repo の書き込み失敗は赤、fork 403 だけは警告。`apply-visibility-labels` は visibility-only でゲート判定には影響しない (#94)
+- **gate の赤は review_status を残す** — detect 失敗・名簿不備・ラベル取得失敗を含む全赤経路で artifact を書く。PR が無くコメント先も無い pre-checkout の赤だけは対象外 (#142)
 
 ## Layer 2（合成器）の配線スケッチ
 

--- a/templates/ci/README.md
+++ b/templates/ci/README.md
@@ -124,15 +124,15 @@ hardening として強く推奨する。
 - **死にパターン警告は「緑だが守れていない」の唯一のシグナル** — 宣言パターンが HEAD の1ファイルにも解決しない時、detect-risk-paths ログに `::warning::` が出る（LC-5: 検知は機械・判断は人間 — check は赤にならない）。展開時（手順 6）と、リネーム・配置変更を含む PR のマージ時に確認し、出ていたら宣言を追随させる。例外は1つ: **auth コードが本当に無いリポの `risk_paths_auth: 'none'` は AUTH 警告が常在する（仕様）** — 「auth コード無し」を確認した記録を宣言行のコメントに残せば、その警告は既知として許容してよい
 - **v0.9.2 で `risk_paths_auth` が増えた（第4常設カテゴリ）** — v0.9.1 以前の展開済みリポにキャリアーを再コピーすると、AUTH を宣言するまで全 PR が赤になる（仕様・fail-closed）。更新 PR に AUTH 宣言（実パス列挙 or `none`）を必ず同梱する
 - **fetch-depth** — 履歴を使う門番（gitleaks / pr-size / history-check / review-labels）は `fetch-depth: 0` が必須（reusable 側に焼き込み済み・浅くすると「diff 解決不能 → 緑」の fail-open になる）
-- **fork PR** — ゲート判定（read）は fork でも必ず走って赤/緑を出す。承認・免除は**作者が単独で起こせるイベント（synchronize / reopened / ready_for_review、pr-size は edited も）の run では常に無効**で、緑に戻せるのは triage 権限者しか起こせないイベント（labeled / unlabeled）だけ — 作者単独の承認持ち回しは fork でも成立しない。ラベル付与・剥がし（write）は 403 で警告になる（可視化の劣化のみ）。**残余**: 剥がせない古いラベルが triage 権限者の別ラベル操作（labeled / unlabeled の run）で再び有効に見える経路は残る — 共有クレデンシャル環境ではこの線引き自体が identity 分離（機械的保証の前提）待ちであり、このゲートの「可視化+監査」位置づけの範囲内。厳密な SHA 束縛が要る場合は方式2（タイムライン3条件 AND）へ
+- **fork PR** — ゲート判定（read）は fork でも必ず走って赤/緑を出す。承認・免除は**作者が単独で起こせるイベント（edited〔title/body edit・base retarget〕/ synchronize / reopened / ready_for_review）の run では常に無効**で、緑に戻せるのは triage 権限者しか起こせないイベント（labeled / unlabeled）だけ — 作者単独の承認持ち回しは fork でも成立しない。ラベル付与・剥がし（write）は失敗時に警告になる（可視化の劣化のみ）。**残余**: 剥がせない古いラベルが triage 権限者の別ラベル操作（labeled / unlabeled の run）で再び有効に見える経路は残る — 共有クレデンシャル環境ではこの線引き自体が identity 分離（機械的保証の前提）待ちであり、このゲートの「可視化+監査」位置づけの範囲内。厳密な SHA 束縛が要る場合は方式2（タイムライン3条件 AND）へ
 - **`pull_request_target` は使わない** — untrusted コードに write トークンを渡す典型的脆弱形（全門番 `pull_request` トリガ）
 - **gitleaks の赤を消しても秘密は無効化されない** — 一度 push した秘密は必ず rotate する。本線は commit 前のローカル hook・CI は最後の網。検知の許容（allowlist）は base 側 `.gitleaks.toml` だけが効く — PR 側の設定・`.gitleaksignore`・inline `gitleaks:allow` は無効化してある（自己緩和封じ）
 - **承認後の push で承認が無効になるのは仕様** — 承認（`risk-reviewed` / `size-exempt`）は「オーナーが見た head SHA」に束縛される。無効化はゲート自身のイベント判定で行われ、ラベル剥がしジョブは可視化のための衛生（「剥がしは機械・貼るのは人間」）
 - **ワークフロー自身の改変は機械的には止められない** — `pull_request` トリガは PR head 側のワークフロー定義（caller の `with:` 入力・呼び出し先タグを含む）で実行されるため、門番を無力化する PR はその無力化された門番で判定される（循環）。防御は PR timeline の監査＋可能なら `.github/workflows/` への CODEOWNERS 必須化。これがこのゲートを「可視化+監査」装置と位置づける理由の一つ
-- **`pr-size.yml` と `review-labels.yml` の caller types は削らない** — `labeled` / `unlabeled` / `ready_for_review` と `edited`（review-labels は base retarget の再評価）が無いと緑が古く残る。`@ci-v1` pin 済みでも `edited` 未追加の caller は従来どおり retarget 防御なしで動くため、追随を推奨するが互換性には影響しない (#99)
+- **`pr-size.yml` と `review-labels.yml` の caller types は削らない** — `labeled` / `unlabeled` / `ready_for_review` と `edited`（pr-size も購読）が無いと緑が古く残る。review-labels では `edited`（title/body edit・base retarget）も synchronize と同様に承認を無効化するため、作者側の PR metadata edit 後はオーナーが `risk-reviewed` を再適用する。`@ci-v1` pin 済みでも `edited` 未追加の caller はこの変更の影響を受けず従来どおり動くため、追随を推奨する (#99)
 - **死にパターン liveness はリポ固有宣言だけ** — `RISK_PATHS_REPO` のみを調べ、汎用網の DEFAULT は意図的に検査しない。網外の新規設定ファイルや別綴りの migrations dir は警告されないため、リポ宣言で補う (#99)
-- **可視化ラベルの失敗分類** — `needs-risk-review` 不在と same-repo の書き込み失敗は赤、fork 403 だけは警告。`apply-visibility-labels` は visibility-only でゲート判定には影響しない (#94)
-- **gate の赤は review_status を残す** — detect 失敗・名簿不備・ラベル取得失敗を含む全赤経路で artifact を書く。PR が無くコメント先も無い pre-checkout の赤だけは対象外 (#142)
+- **可視化ラベルの失敗分類** — same-repo のラベル一覧取得失敗・`needs-risk-review` 不在・書き込み失敗は赤。fork のラベル一覧取得失敗・ラベル不在・書き込み失敗は、contributor がリポ設定を直せないため警告。`apply-visibility-labels` は visibility-only でゲート判定には影響しない (#94)
+- **gate の赤は review_status を残す** — `Evaluate gate` step 内の全赤経路（明示的な script exit と EXIT trap が捕捉する予期しない error）で artifact を書く。対象外は、PR が無くコメント先も無い pre-checkout の non-`pull_request` event の赤と、script の前後で起きる infrastructure failure（actions/checkout failure・runner/cancellation kill）であり、これらは artifact を upload せず `if-no-files-found: warn` の warning として現れる (#142)
 
 ## Layer 2（合成器）の配線スケッチ
 

--- a/templates/ci/review-labels.yml
+++ b/templates/ci/review-labels.yml
@@ -1,7 +1,7 @@
 name: Risk Review Gate
 on:
   pull_request:
-    types: [opened, synchronize, reopened, labeled, unlabeled, ready_for_review]
+    types: [opened, synchronize, reopened, edited, labeled, unlabeled, ready_for_review]
 permissions: {contents: read}
 concurrency: {group: 'risk-review-${{ github.event.pull_request.number }}', cancel-in-progress: true}
 jobs:


### PR DESCRIPTION
Closes #121, closes #94, closes #142, closes #99 (handoff [H-A], one branch / one PR — identical declared file set; campaign: caty-ai/family-os#56).

Hardens the reusable risk-review gate on four axes, all backward compatible for `@ci-v1` callers (no new `workflow_call` inputs, no permission changes, no job/step/output/artifact-name changes):

- **#121** `.github/release-sync-ignore` joins `RISK_PATHS_DEFAULT` (next to `.github/risk-reviewers.txt`): a PR that adds a T-5 exemption now goes red pending `risk-reviewed`. Sweep note: `.github/CODEOWNERS` is the other control file in the same position; left for a follow-up Issue rather than widening this PR.
- **#142** every red exit inside the `Evaluate gate` step writes the `review_status` artifact with a class-naming summary: detect failure, invalid `risk_hit`, roster missing / empty / placeholder, label-fetch failure (via a `jq`-built `write_action_required` helper) plus an `EXIT` trap for any unexpected non-zero exit that reached no decision (never overwrites an existing decision). `if-no-files-found` becomes `warn`. Recorded exemptions: the pre-checkout "not a pull_request event" red (no PR to comment on) and infrastructure failures around the script (checkout / runner / cancellation), which surface as the upload warning.
- **#94** `apply-visibility-labels` no longer reports success while attaching nothing: the label list is fetched (`gh api --paginate`); on a same-repo PR a missing `needs-risk-review` is a red naming the label and the `gh label create` command, and a failed add is red; on a fork PR all three are warnings (a fork contributor cannot fix repo labels; 403 on write is expected). Option (b) of the Issue was chosen because option (a) (creating labels) needs `issues: write`, a caller-side permission change. The job stays visibility-only and never required.
- **#99** (1) `pull_request.edited` is now an author-triggerable event like `synchronize`: it voids approval unconditionally (base retarget keeps a retarget-specific message; title/body edits use the head-changed message) and triggers the strip step. The caller stencil and the handbook's own caller subscribe `edited`. 追随判定 for existing `@ci-v1` callers: recommended (add `edited` to `types`), not required — without it they keep today's behaviour. (2) DEFAULT-pattern liveness: documented as a limitation (DEFAULT is a generic net; 0-match warnings for it would be noise) in the reusable comment and the README.
- Hardening adopted from the panel: the gate is green only when `risk_hit` is exactly `false`; any other value is red with a payload (FP-6).

## Files touched (= WIP declaration, 4 files)

- `.github/workflows/reusable-review-labels.yml`
- `.github/workflows/review-labels.yml`
- `templates/ci/review-labels.yml`
- `templates/ci/README.md`

`git diff --stat origin/main...0d1d313` = exactly these 4 files (3 commits: `62edbb0` implementation, `95329f3` panel delta, `0d1d313` delta-2). No undeclared files. Intersection with PR #145 (`templates/ci/README.md`, different section) recorded above; serialization = #145 first, this PR rebases + re-verifies before merge (L0-7).

## 完了記録 (L1-7)

**候補 commit SHA: `0d1d313`** (= PR head at review completion)

### Done when → PASS/FAIL

**#121**
1. `.github/release-sync-ignore` in `RISK_PATHS_DEFAULT` — **PASS.** Evidence (2026-09-04): `reusable-review-labels.yml` RISK_PATHS_DEFAULT now lists `.github/release-sync-ignore` directly after `.github/risk-reviewers.txt`; 3 seats independently confirmed it is not covered by any other DEFAULT entry and resolves via the same `:(glob,icase)` loop (`git ls-files -- ':(glob,icase).github/release-sync-ignore'` → tracked file in this repo).
2. A PR touching it observed going red pending `risk-reviewed` — **PASS (equivalent live evidence) / exact-file observation deferred to Issue close.** Evidence: the `.github/workflows/**` hit on this PR itself produced the label-absent red (run 33782538074, `##[error]high-risk paths changed but the risk-reviewed label is not present`) through the identical matching loop; a PR that touches only the ignore file has not been opened (no such change is wanted today). The Issue's LC-1 trigger stays as written.

**#94**
3. Missing label ⇒ create idempotently or fail red naming the label — **PASS (option b).** Evidence: extracted-step probe (stubbed `gh`, real bash) L1 `label list without needs-risk-review → exit 1` with `::error::label 'needs-risk-review' is missing in caty-ai/probe; create it per templates/ci/README.md step 3: gh label create needs-risk-review …`; L4 same-repo add failure → exit 1; L5 list failure → exit 1; L2 label present → exit 0 + `::notice::needs-risk-review label attached`; L3/L6/L7 fork variants → exit 0 with warnings. 16/16 (probe.log, 2026-09-04).
4. One run on a repo without the labels (run URL) — **N/A (blocked, with substitute evidence).** Reason: this repo has both labels and no disposable repo exists; creating one is an owner decision (Step 0). Substitute: live run on this repo exercising the new list→check→add path end to end — run 33785402466 `##[notice]needs-risk-review label attached to PR #149.` (label present branch) plus probe L1/L5 for the missing/failed branches. The Issue is closed on the code + probe evidence; the owner may run a disposable-repo confirmation at `ci-v1` advance time.
5. Regression note in templates/ci README — **PASS.** Evidence: README step 3 sentence + 落とし穴 bullet「可視化ラベルの失敗分類」(same-repo red / fork warning / strip hygiene-only).

**#142**
6. Every red exit in `gate` writes a valid action_required payload, or a recorded exemption — **PASS.** Evidence: probe G1 (detect failure) / G2–G4 (roster missing / empty / placeholder) / G5 (label fetch failure) / G11–G12 (risk_hit '' / unexpected) / G9 (injected unexpected error → EXIT trap payload, rc preserved) all `exit ≠ 0` with `sed 's/^review_status=//' | jq -e .` valid; 4 seats independently traced all 15–16 `exit 1` sites in the step; recorded exemptions (pre-checkout non-PR red; checkout/runner/cancel infra failures) written in the workflow comment and README. Live: label-absent red uploaded `review-status-risk-review` 373B (run 33782538074) and void red uploaded 379B (runs 33784604083, 33785402466).
7. Payload summaries name the failure class — **PASS.** Evidence: titles `Risk detection failed` / `Risk detection output invalid` / `Risk reviewer roster missing|empty|placeholder` / `Risk review label fetch failed` / `Risk review gate error` (trap) — probe asserts title/summary substrings per scenario.
8. actionlint clean; artifact JSON validated — **PASS.** Evidence: `actionlint 1.7.12` rc=0 on reusable + both callers (Alpha + 5 seats); `jq -e` on every probe payload and on all 10 inline literals (GLM seat).

**#99**
9. Caller stencil subscribes `edited` and/or the reusable's void design handles it — **PASS (both).** Evidence: `templates/ci/review-labels.yml` and `.github/workflows/review-labels.yml` `types` include `edited`; gate voids on `edited` (probe G6 retarget → `base branch retargeted from 'staging' to 'main'` payload; G7/G10 title-body edit with stale approval → void red, previously green — the Opus r1 blocking); live void red on this PR's `synchronize` runs. Seat-modelled decision table: only `opened`/`labeled`/`unlabeled` reach label evaluation.
10. DEFAULT liveness warning or documented limitation — **PASS (documented).** Evidence: detect-job comment above the dead-pattern loop + README bullet「死にパターン liveness はリポ固有宣言だけ」.
11. 既存 caller への追随要否 1行 — **PASS.** README: 追随推奨・互換性には影響しない (`@ci-v1` pin 済みで `edited` 未追加の caller は従来どおり).

**Handoff Done when**: caller-side change not required, proven on one repo — **PASS.** Evidence: this repo's own caller was unchanged for #121/#94/#142 (the `edited` addition is the opt-in #99 part) and its runs on `62edbb0` / `95329f3` / `0d1d313` exercised the new reusable end to end (label attached, artifacts uploaded, void red on synchronize).

### Review (L1-3 / L1-10 / L1-11)

- Implementer: **Codex GPT-5.6 Sol** (profile sol, effort high; commits `62edbb0`, `95329f3`, orchestrated/verified/committed by Alpha) + Alpha for delta-2 `0d1d313` (comment/README scoping + 2-line strip echo restructure). Reviewers: 異種5席 **Opus 5 / GLM 5.3 / Grok 4.6 / Kimi K3 / Codex Sol** — fresh context, read-only, r1 blind. Round trail: r1 on `62edbb0` (Opus NO-GO B1 demonstrated: `edited` title/body re-evaluation green; Codex NO-GO ×3; 5-seat convergence on README artifact-coverage overclaim) → panel delta `95329f3` (**5/5 cumulative GO**, MINORs only) → delta-2 `0d1d313` (focused confirmation: **5/5 cumulative GO**, 1 LOW wording note). Full record with requested/actual models and the correlated-seats exception (codex-sol seat × codex-sol writer, seat-decree 2026-08-12): r1 [comment-5529459396](https://github.com/caty-ai/family-dev-handbook/pull/149#issuecomment-5529459396), delta/delta-2 comment below.

### CI state

At `0d1d313`: gitleaks / history-check / pr-size (+strip) / repo-state / test-lint (lint, test, test-macos) all pass; `risk-review-gate / risk-review-gate` red is the gate's own designed void-on-synchronize wait (this PR touches `.github/workflows/**`), not a code failure — it flips green on the roster owner's `labeled` event, which is required before merge. `apply-visibility-labels` green with the label attached (run 33785402466).

### release

- **release: v0.23.0** — annotated tag on the merge commit + GitHub Release (release-sync carrier), then advance the `ci-v1` moving tag to the same commit (backward-compatible change). Identifier note: PR #145 (queued ahead, same repo) declares `v0.22.0`; if #145 has not shipped when this PR merges, this PR takes `v0.22.0` and the MERGED comment records the rename per T-5 (one line). Rollout note for `ci-v1` advance: callers gain nothing new unless they add `edited` to `types`; the README documents the recommendation.
- **previous release: v0.21.0** — fulfilled (GitHub Release exists, published 2026-09-01, currently Latest).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
