### PR TITLE
fix(publication-gate): selftest reference/production parity at start 0 + casefold dedupe; posture notes (#150)

### DIFF
--- a/templates/publication-gate/README.md
+++ b/templates/publication-gate/README.md
@@ -232,9 +232,13 @@ summary は必ず `enumeration: git` または `enumeration: rglob-fallback` と
 ## 2026-09 改訂（#150）— 再コピーは任意
 
 - この改訂は、この PR の merge 時に handbook release `v0.26.0` として切る。
-- red/green outcome は変わらない。caller-visible な差分は、repository name の直後が `&` / `?` / `#` / `=` の nested candidate（例: `github.com/<slug>/repo&x=1`）で、finding が `repo&x=1` ではなく field-cut した `repo` を報告することだけである。
-- Items 2–4 は上記「スキャン対象と Git の無い環境」に accepted posture として記録しただけで、出力変更はない。
-- `v0.24.0` に pinned の adopter も再コピーは任意であり、次の必須再コピー対象は次回の behavior-changing revision のままである。
+- `--no-registry` の caller では red/green は変わらず、finding だけが `&` / `=` の直後で
+  field-cut した名前（`repo&x=1` → `repo`）を報告する。`--registry` の caller では
+  `&` / `=` cut 名も `?` / `#` と同様に registry allowlist と照合されるため、登録済み repo
+  への `github.com/<slug>/<repo>&…` 参照は旧版の誤検知（赤）が解消して緑になり、未登録 repo は cut 名のまま赤である。GitHub の repository 名は `&` / `=` を含めないので真の違反が緑になることはなく、scheme 無しの `github.com/<slug>&…` / `github.com/<slug>=…`（gist 含む）は新たに personal account profile として赤になる（fail-closed 側の変更）。
+- 項目 2–4 は上記「スキャン対象と Git の無い環境」に accepted posture として記録した整理であり、この改訂の caller-visible な差分は前項の nested candidate まわりに限られる。
+- `v0.24.0` に pinned の adopter も再コピーは任意であり、真の違反の red/green は変わらないが、registry を使う CI では上記の誤検知解消と scheme 無し profile の追加赤が出うるため outcome-neutral ではない。
+  ただし、公開済みテキストに scheme 無しの `github.com/<slug>&…` / `github.com/<slug>=…` を含む adopter は、旧版では緑・再コピー後に赤になる形のため再コピーを推奨し、それ以外は引き続き任意とする。
 
 ## family-os / organization `.github` からの移行
 

--- a/templates/publication-gate/README.md
+++ b/templates/publication-gate/README.md
@@ -192,6 +192,10 @@ binary suffix の例には `.png` と `.icns` が含まれる。`.plist` は bin
 通常どおり全文を検査し、UTF-16 XML plist は source-read として赤にする。binary plist は `.plist` / `.bplist`
 の `bplist00` signature により skip する。鍵・証明書コンテナは意図的に binary set に入れない＝赤。
 
+- binary skip の個別列挙は上限を設けない。1 skipped binary につき1行の名前が adopter の grep 用 audit trail であり、上限は名前を隠す一方、総数は既存の `binary files skipped: N` が示す。
+- `.eps` は `BINARY_SUFFIXES` に残す。decode-first のため ASCII EPS は text としてスキャンされ、非 UTF-8 の EPS だけが binary として skip される。`.fig` も同じ扱いである。
+- `.DS_Store` は exact case のまま扱う。macOS が書く名前は正確に `.DS_Store` であり、非 UTF-8 の `.ds_store` は意図どおり fail-closed で赤になる。
+
 `BINARY_SUFFIXES` は stencil 上流の公開ポリシーであり、byte-identical copy を採用するリポが局所的に
 調整する対象ではない。未知の suffix が非 UTF-8 として赤になった場合は、ファイルを UTF-8 へ変換する、
 Git mode なら publishable corpus から untrack する、または suffix 追加の upstream PR を開く、のいずれかで
@@ -224,6 +228,13 @@ summary は必ず `enumeration: git` または `enumeration: rglob-fallback` と
   sample を使わず自前 denylist を書く場合も同等のルールを載せる。
 - nested host を含む URL 候補の personal-url 検査は、上記「個人用 URL」節を参照する。
 - 再コピー対象は、この変更を含む handbook release（この PR の merge 時に `v0.24.0` として切る）。
+
+## 2026-09 改訂（#150）— 再コピーは任意
+
+- この改訂は、この PR の merge 時に handbook release `v0.26.0` として切る。
+- red/green outcome は変わらない。caller-visible な差分は、repository name の直後が `&` / `?` / `#` / `=` の nested candidate（例: `github.com/<slug>/repo&x=1`）で、finding が `repo&x=1` ではなく field-cut した `repo` を報告することだけである。
+- Items 2–4 は上記「スキャン対象と Git の無い環境」に accepted posture として記録しただけで、出力変更はない。
+- `v0.24.0` に pinned の adopter も再コピーは任意であり、次の必須再コピー対象は次回の behavior-changing revision のままである。
 
 ## family-os / organization `.github` からの移行
 

--- a/templates/publication-gate/README.md
+++ b/templates/publication-gate/README.md
@@ -229,15 +229,21 @@ summary は必ず `enumeration: git` または `enumeration: rglob-fallback` と
 - nested host を含む URL 候補の personal-url 検査は、上記「個人用 URL」節を参照する。
 - 再コピー対象は、この変更を含む handbook release（この PR の merge 時に `v0.24.0` として切る）。
 
-## 2026-09 改訂（#150）— 再コピーは任意
+## 2026-09 改訂（#150）— 再コピーは任意（1形状のみ推奨）
 
 - この改訂は、この PR の merge 時に handbook release `v0.26.0` として切る。
-- `--no-registry` の caller では red/green は変わらず、finding だけが `&` / `=` の直後で
-  field-cut した名前（`repo&x=1` → `repo`）を報告する。`--registry` の caller では
-  `&` / `=` cut 名も `?` / `#` と同様に registry allowlist と照合されるため、登録済み repo
-  への `github.com/<slug>/<repo>&…` 参照は旧版の誤検知（赤）が解消して緑になり、未登録 repo は cut 名のまま赤である。GitHub の repository 名は `&` / `=` を含めないので真の違反が緑になることはなく、scheme 無しの `github.com/<slug>&…` / `github.com/<slug>=…`（gist 含む）は新たに personal account profile として赤になる（fail-closed 側の変更）。
+- registry の有無によらず、scheme 無しの `github.com/<slug>&…` / `github.com/<slug>=…`
+  （`www.` 付き・大小文字違い・gist 含む）は新たに personal account profile として赤になる
+  （fail-closed 側の変更。scheme 付きの同形は旧版から赤）。それ以外の `--no-registry` の caller では
+  red/green は変わらず、finding だけが `&` / `=` の直後で field-cut した名前（`repo&x=1` → `repo`）を
+  報告する。`--registry` の caller では `&` / `=` cut 名も `?` / `#` と同様に registry allowlist と
+  照合されるため、登録済み repo への `github.com/<slug>/<repo>&…` 参照は旧版の誤検知（赤）が解消して
+  緑になり、未登録 repo は cut 名のまま赤である。GitHub の repository 名は `&` / `=` を含めないので、
+  真の違反が緑になることはない。
 - 項目 2–4 は上記「スキャン対象と Git の無い環境」に accepted posture として記録した整理であり、この改訂の caller-visible な差分は前項の nested candidate まわりに限られる。
-- `v0.24.0` に pinned の adopter も再コピーは任意であり、真の違反の red/green は変わらないが、registry を使う CI では上記の誤検知解消と scheme 無し profile の追加赤が出うるため outcome-neutral ではない。
+- `v0.24.0` に pinned の adopter も再コピーは任意であり、真の違反の red/green は変わらないが、
+  scheme 無し profile の追加赤（モード共通）と、registry を使う CI での上記の誤検知解消が出うるため
+  outcome-neutral ではない。
   ただし、公開済みテキストに scheme 無しの `github.com/<slug>&…` / `github.com/<slug>=…` を含む adopter は、旧版では緑・再コピー後に赤になる形のため再コピーを推奨し、それ以外は引き続き任意とする。
 
 ## family-os / organization `.github` からの移行

--- a/templates/publication-gate/check_publication_gate.py
+++ b/templates/publication-gate/check_publication_gate.py
@@ -1354,6 +1354,8 @@ def selftest_scanners():
         "https://example.org/?u=notgithub." "com/neutral-owner/nope",
         "https://example.org/?u=github." "com/neutral-owner/one&b=github." "com/neutral-owner/two",
         "github." "com/neutral-owner/repo&x=1",
+        "github." "com/neutral-owner&x=1",
+        "github." "com/neutral-owner=1",
         "github." "com/neutral-owner/Repo?x=github." "com/neutral-owner/repo",
     )
     for candidate in nested_reference_cases:
@@ -1370,6 +1372,45 @@ def selftest_scanners():
         )
         == {"repo"},
         "nested bare-ampersand repository name is field-cut",
+    )
+    _selftest_check(
+        set(
+            _nested_personal_urls(
+                "github." "com/neutral-owner&x=1", "neutral-owner"
+            )
+        )
+        == {None},
+        "nested bare-ampersand account profile is field-cut",
+    )
+    ampersand_registry = _fixture_registry()
+    ampersand_registry["modules"].append(
+        {"name": "Repo", "repo": "neutral-owner/repo", "status": "published"}
+    )
+    ampersand_allowlisted_failures = []
+    _selftest_check(
+        check_personal_urls(
+            {"README.md": "github." "com/neutral-owner/repo&x=1\n"},
+            "neutral-owner",
+            ampersand_registry,
+            ampersand_allowlisted_failures,
+        )
+        == 1
+        and ampersand_allowlisted_failures == [],
+        "registry allowlist matches ampersand-cut repository name",
+    )
+    ampersand_unregistered_failures = []
+    _selftest_check(
+        check_personal_urls(
+            {"README.md": "github." "com/neutral-owner/other&x=1\n"},
+            "neutral-owner",
+            ampersand_registry,
+            ampersand_unregistered_failures,
+        )
+        == 1
+        and len(ampersand_unregistered_failures) == 1
+        and "unknown repository neutral-owner/other"
+        in ampersand_unregistered_failures[0],
+        "unregistered ampersand-cut repository stays red",
     )
     two_repo_registry = _fixture_registry()
     two_repo_registry["modules"].extend(

--- a/templates/publication-gate/check_publication_gate.py
+++ b/templates/publication-gate/check_publication_gate.py
@@ -401,10 +401,7 @@ def _nested_personal_urls(candidate, account_slug):
             next_marker = next(marker_indexes, None)
         if character in split_characters:
             previous_split = index
-    repo_name = _personal_url(candidate, account_slug)
-    if repo_name is not False and unseen(repo_name):
-        yield repo_name
-    field_end = 0
+    field_end = -1
     for start in range(len(candidate)):
         if start not in starts:
             continue
@@ -909,6 +906,7 @@ def selftest_scanners():
         )
         field_end = -1
         matches = set()
+        reported = set()
         for start in sorted(starts):
             if field_end < start:
                 field_end = start
@@ -916,6 +914,14 @@ def selftest_scanners():
                     field_end += 1
             repo_name = _personal_url(candidate[start:field_end], account_slug)
             if repo_name is not False:
+                name = (
+                    account_slug
+                    if repo_name is None
+                    else account_slug + "/" + repo_name
+                ).casefold()
+                if name in reported:
+                    continue
+                reported.add(name)
                 matches.add(repo_name)
         return matches
 
@@ -1347,6 +1353,8 @@ def selftest_scanners():
         "https://example.org/?u=neutral-owner.github." "io/page",
         "https://example.org/?u=notgithub." "com/neutral-owner/nope",
         "https://example.org/?u=github." "com/neutral-owner/one&b=github." "com/neutral-owner/two",
+        "github." "com/neutral-owner/repo&x=1",
+        "github." "com/neutral-owner/Repo?x=github." "com/neutral-owner/repo",
     )
     for candidate in nested_reference_cases:
         _selftest_check(
@@ -1354,6 +1362,15 @@ def selftest_scanners():
             == reference_nested_personal_urls(candidate, "neutral-owner"),
             "nested boundary walk matches reference: %s" % candidate,
         )
+    _selftest_check(
+        set(
+            _nested_personal_urls(
+                "github." "com/neutral-owner/repo&x=1", "neutral-owner"
+            )
+        )
+        == {"repo"},
+        "nested bare-ampersand repository name is field-cut",
+    )
     two_repo_registry = _fixture_registry()
     two_repo_registry["modules"].extend(
         (


### PR DESCRIPTION
Closes #150

Post-#147 panel nits for the shared publication-gate template (single-file checker adopters copy byte-identically). All four items from #150 are landed: item 1 as code, items 2–4 as recorded accepted posture.

- **Item 1 (code)** — production `_nested_personal_urls` drops the redundant whole-candidate parse and inits `field_end = -1`, so the start-0 span is field-cut like every other start: `github.com/<slug>/repo&x=1` now reports `repo` (was `repo&x=1`). The selftest reference walk dedupes case-insensitively keeping first-seen spelling (mirrors production `unseen()`). Corpus gains a bare-`&` string and a mixed-case duplicate, plus an explicit field-cut assertion pinned independently of the reference. Selftest 143 → **151** assertions (r1 146; +3 registry/bare-profile contract pins and +2 corpus strings from the review deltas).
- **Item 2** — per-file binary listing stays **uncapped** (accepted posture: the per-file lines are the adopter's grep audit trail; the count line already gives the total).
- **Item 3** — `.eps` stays in `BINARY_SUFFIXES` (accepted posture: decode-first, ASCII EPS is scanned as text; same for `.fig`).
- **Item 4** — `.DS_Store` stays exact-case (accepted posture: macOS writes that exact name; a non-UTF-8 `.ds_store` is red by design).
- README: three posture lines under 「スキャン対象と Git の無い環境」+ a 「2026-09 改訂（#150）— 再コピーは任意」 adopter delta note.

## Files touched (= WIP declaration, 2 files)

- `templates/publication-gate/check_publication_gate.py`
- `templates/publication-gate/README.md`

`git diff --stat origin/main...9410937` = exactly these 2 files (83 insertions / 4 deletions, 3 commits: `e5fd7ec` implementation · `c5e6b9a` delta 1–2 · `9410937` delta 3 README-only). No undeclared files.

## 完了記録 (Completion record)

**候補 commit SHA: `9410937`** (= PR head; `e5fd7ec` reviewed r1 → `c5e6b9a` reviewed r2 → `9410937` doc-only fold of the r2 nits)

implementer: Codex GPT-5.6 Sol (`codex exec --profile sol -s workspace-write`, via sitter-run; brief by Alpha, committed by Alpha because the sandbox cannot take the shared worktree index lock)
reviewer: 異種3席 by `loom-seats --size M` = GLM 5.3 / Opus 5 / Kimi K3 → Kimi absent (403 weekly quota, 2026-09-05) → `loom-seats --size M --absent kimi-k3` = **GLM 5.3 / Opus 5 / Grok 4.6**. Round record: r1 https://github.com/caty-ai/family-dev-handbook/pull/151#issuecomment-5544456854 · r2 https://github.com/caty-ai/family-dev-handbook/pull/151#issuecomment-5544541508

### Done when → PASS/FAIL

1. Reference and production yield identical name sets for every corpus string incl. bare-`&` and mixed-case duplicate; assertion count +≥2 — **PASS**. Evidence (2026-09-05, `9410937`): `python3 -B templates/publication-gate/check_publication_gate.py --selftest` → `PASS (publication gate selftest; assertions: 151)` (was 143 in-repo / 142 copied-alone; the +1 is the in-repo copy probe). Alpha old-vs-new oracle (importlib, origin/main copy vs `e5fd7ec`, 34 strings = the 23-string corpus + 11 adversarial): **0 strings lost a detection**; 3 strings differ in spelling only, all of the `&`/`=`-cut kind (`repo&x=1`→`repo`, `repo=github.com`→`repo`, `dot&x=1`→`dot`). Mutation checks (temp copies): revert production to whole-candidate parse + `field_end = 0` → selftest red at `nested boundary walk matches reference: …/repo&x=1`; `field_end = 0` alone → red at `bare-at personal repository URL`; drop the reference casefold dedupe → red at `…/Repo?x=…/repo`. All three mutants red = the new assertions bite.
2. Items 2–4 each changed or recorded as accepted posture in the template README, one line each — **PASS** (three posture lines, none changed in code; see README diff).
3. Adopter delta list updated if any caller-visible output changes — **PASS**: item 2 unchanged (no output change), but item 1 is caller-visible, so a 「2026-09 改訂（#150）」 note records it. Review seats measured that it is **not** outcome-neutral: `--registry` callers see allowlisted `repo&x=1` go red→green (false-positive removal; unregistered stays red under the cut name), and scheme-less bare profiles `github.com/<slug>&…`/`=…` go green→red in both modes (fail-closed). The note states both directions; re-copy is optional except **recommended** for adopters carrying the bare-profile shape. Both contracts are pinned by selftest assertions.

### Review (L1-3 / L1-10 / L1-11)

Size S/M / 公開前ゲート領域 → 3 seats (`loom-seats --size M`, writer codex-sol; no same-family seat). r1 at `e5fd7ec`: GLM GO-with-nits · Opus NO-GO · Grok NO-GO — 3/3 converged on one MAJOR (README over-promised "red/green unchanged"; code sound, F1 clean on 158 probe strings). Delta 1–2 → r2 at `c5e6b9a`: **Opus GO · GLM GO-with-nits · Grok GO-with-nits**, zero code findings, residual doc nits folded into `9410937` (delta 3). Alpha arbitration: contract kept as coded (`&`/`=` cut names allowlist-match like `?`/`#`; bare-profile red is intended).

### CI state

Required checks green at `e5fd7ec` and `c5e6b9a` (11 pass: test-lint lint/test/test-macos · gitleaks · history-check · pr-size · risk-review-gate ×3 · repo-state · watch); `9410937` (README-only) re-run — result appended in the ball:human comment. Local: `make test` green (`suites: declared=6 executed=6 skipped=0`), `make lint` green, selftest 151.

### release

- **release: v0.26.0** — annotated tag on the merge commit + GitHub Release (release-sync carrier). Template behaviour changes (finding text for `&`/`?`/`#`/`=`-cut nested names; selftest corpus) → 出荷相当. Number measured at kickoff with `gh release list` (Latest = v0.25.0, 2026-09-04); re-measured at merge time per the T-5 rename rule.
- **previous release: v0.25.0** — fulfilled (GitHub Release exists and is Latest: https://github.com/caty-ai/family-dev-handbook/releases/tag/v0.25.0, published 2026-09-04, PR #149).

### Adopter follow-up

Re-copy for family-os / caty-ai/.github (pinned at v0.24.0) is **optional** per the README delta note, recommended only for adopters whose published text carries a scheme-less `github.com/<slug>&…`/`=…` bare profile. Alpha checked both adopters' publishable corpus for that shape after merge (see the MERGED comment); no re-copy Issue is opened unless the shape is present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
