### PR TITLE
docs(ci): ci-v* is a protected tag; write-path changes cut ci-v2 (#116)

### DIFF
--- a/templates/ci/README.md
+++ b/templates/ci/README.md
@@ -60,6 +60,31 @@ job 名の変更など required checks の再キーが必要になる変更）�
 呼び出し元だけは `@ci-v1` を pin せずローカルパス (`./.github/workflows/reusable-<gate>.yml`) で参照する
 — 改訂 PR が古いタグの内容で自己検証されるデッドロックを避けるため。
 
+### `ci-v*` は保護タグ — 作成・移動・削除は repository admin のみ
+
+`ci-v*` には handbook リポの **tag ruleset**（`target: tag`・`refs/tags/ci-v*`・rules = creation /
+update / deletion・enforcement active）が張られており、bypass actor は repository admin
+（`RepositoryRole` admin）だけである。意味は「**bypass でない主体 — write / maintain 権限の
+collaborator・GitHub App・workflow の `GITHUB_TOKEN` — は `ci-v*` を作れず、動かせず、消せない**」で
+あって、pin の凍結ではない。`ci-v1` は moving major のままで、前進はこれまでどおり owner GO 後に
+admin アカウントで行い [#116](https://github.com/caty-ai/family-dev-handbook/issues/116) に記録する。
+採用側が前提にしてよいのはここまでで、repository admin（現在の顔ぶれと bypass の実測は #116）と
+その運用記録への信頼は残る — admin は ruleset 自体も編集できる。ruleset の実測は一覧
+（`gh api repos/caty-ai/family-dev-handbook/rulesets`）では `conditions` / `rules` / `bypass_actors`
+が返らないため、`gh api repos/caty-ai/family-dev-handbook/rulesets/<id>` の全文を #116 に貼る。
+
+**次のいずれかを含む改訂は `ci-v1` に流さず `ci-v2` を切る**（レビュアーは reusable の diff で照合し、
+該当すれば reject する）:
+
+1. 既存 reusable が caller に要求する `permissions:` を新規に追加する、または範囲を広げる
+   （`contents: write` を要求してよいのは `reusable-release-sync.yml` の Release 作成だけ）
+2. `reusable-release-sync.yml` が checkout する・tag 側のリポ内容を読み込み実行する・GitHub API での
+   Release 作成以外の書き込みを行う
+3. `contents: write` を要求する新しい reusable を `ci-v1` の pin 対象に加える
+
+`ci-v1` に流してよいのは、上記 3 点を保ったままの read-path の後方互換な改善と不具合修正だけである。
+`ci-v2` を切るときはリリースノート先頭に全採用リポの `uses:` 更新手順を載せる。
+
 ## release-sync — tag push 後の Release 履行
 
 `release-sync.yml` は PR の7番目の門番ではない。annotated な SemVer `v*` tag の push を受け、
@@ -86,7 +111,7 @@ tag 等、明示的に Release を作らない tag だけを列挙し、legacy l
 これは family の CI キャリアーで初めて `contents: write` を要求する門番であり、moving tag の
 `ci-v1` が初めて書き込み経路を守る。reusable は checkout せず、tag 側のリポ内容を実行せず、
 GitHub API で Release を作る以外を変更しない。この不変条件を崩す改訂は後方互換な `ci-v1` 更新と
-みなさず、バージョニング判断をやり直す。
+みなさず、`ci-v2` を切る（判定基準は上記「`ci-v*` は保護タグ」節の 3 項目）。
 
 導入時には push 権限を持つ token で次を実行し、active exemption list と zero-RED を記録する
 （read-only token では draft が見えないため、script は exit 2 で報告を拒否する）。

--- a/templates/ci/README.md
+++ b/templates/ci/README.md
@@ -66,24 +66,29 @@ job 名の変更など required checks の再キーが必要になる変更）�
 update / deletion・enforcement active）が張られており、bypass actor は repository admin
 （`RepositoryRole` admin）だけである。意味は「**bypass でない主体 — write / maintain 権限の
 collaborator・GitHub App・workflow の `GITHUB_TOKEN` — は `ci-v*` を作れず、動かせず、消せない**」で
-あって、pin の凍結ではない。`ci-v1` は moving major のままで、前進はこれまでどおり owner GO 後に
-admin アカウントで行い [#116](https://github.com/caty-ai/family-dev-handbook/issues/116) に記録する。
-採用側が前提にしてよいのはここまでで、repository admin（現在の顔ぶれと bypass の実測は #116）と
-その運用記録への信頼は残る — admin は ruleset 自体も編集できる。ruleset の実測は一覧
-（`gh api repos/caty-ai/family-dev-handbook/rulesets`）では `conditions` / `rules` / `bypass_actors`
-が返らないため、`gh api repos/caty-ai/family-dev-handbook/rulesets/<id>` の全文を #116 に貼る。
+あって、pin の凍結ではない。`ci-v1` は moving major のままで、前進は owner GO 後に admin アカウントで
+行い [#116](https://github.com/caty-ai/family-dev-handbook/issues/116) に記録する。採用側が前提に
+してよいのはここまでで、repository admin（現在の顔ぶれと bypass の実測は #116。admin 権限を付与した
+GitHub App も bypass 側に入り得る）とその運用記録への信頼は残る — admin は ruleset 自体も編集できる。
+ruleset の実測は一覧（`gh api repos/caty-ai/family-dev-handbook/rulesets`）では `conditions` /
+`rules` / `bypass_actors` が返らないため、`gh api repos/caty-ai/family-dev-handbook/rulesets/<id>`
+の全文を #116 に貼る。
 
 **次のいずれかを含む改訂は `ci-v1` に流さず `ci-v2` を切る**（レビュアーは reusable の diff で照合し、
-該当すれば reject する）:
+1 つでも該当すれば reject する。上の段落の破壊的変更 — 入力の削除・意味変更、job 名の変更 — も従来どおり
+`ci-v2` であり、この 3 項目はそれに write-path の軸を足すもの）:
 
-1. 既存 reusable が caller に要求する `permissions:` を新規に追加する、または範囲を広げる
-   （`contents: write` を要求してよいのは `reusable-release-sync.yml` の Release 作成だけ）
-2. `reusable-release-sync.yml` が checkout する・tag 側のリポ内容を読み込み実行する・GitHub API での
-   Release 作成以外の書き込みを行う
-3. `contents: write` を要求する新しい reusable を `ci-v1` の pin 対象に加える
+1. 既存 reusable が caller に要求する `permissions:` に **write 系キーを追加する、または read → write に
+   広げる**（workflow 級・job 級を問わない。`permissions:` ブロックの削除で既定が広がる場合も含む。
+   `contents: write` を要求してよいのは `reusable-release-sync.yml` の Release 作成だけ）
+2. `reusable-release-sync.yml` が次のいずれかを行う — (a) `actions/checkout` / `git clone` /
+   同等の取得、(b) tag が指すツリーやファイルの取得・実行（tag object の message を notes に読むのは可）、
+   (c) Release 作成（`POST …/releases`）以外の GitHub への書き込み
+3. **何らかの write 系 `permissions:`・書き込み用 credential・外部状態への書き込み**を要求する新しい
+   reusable を追加し、`@ci-v1` から `uses:` できる状態にする（`contents: write` に限らない）
 
-`ci-v1` に流してよいのは、上記 3 点を保ったままの read-path の後方互換な改善と不具合修正だけである。
-`ci-v2` を切るときはリリースノート先頭に全採用リポの `uses:` 更新手順を載せる。
+`ci-v1` に流してよいのは、上記 3 項目のいずれにも該当しない read-path の後方互換な改善と不具合修正だけ
+である。`ci-v2` を切るときはリリースノート先頭に全採用リポの `uses:` 更新手順を載せる。
 
 ## release-sync — tag push 後の Release 履行
 


### PR DESCRIPTION
Closes #116

## Why

`ci-v1` is a moving major tag consumed by 14 family repos, and since #103 it carries a `contents: write` workflow. Branch protection does not cover tags, so anyone with write access could re-point it. Issue #116 (3-seat converged finding from family-os#99) asks for a tag ruleset plus README text that adopters can rely on, and a decision on where write-path changes go.

## What changed

- `templates/ci/README.md` "バージョニング" section: new subsection "`ci-v*` は保護タグ" — states the tag ruleset (target tag, `refs/tags/ci-v*`, creation/update/deletion, bypass = repository admin), what adopters may and may not rely on (non-bypass actors cannot mutate; not a frozen pin; admins and the recorded advance flow are still trusted), how to measure it (`GET rulesets/<id>`, not the list endpoint), and a **3-item reject checklist** for changes that must cut `ci-v2` instead of flowing into `ci-v1`. The release-sync invariant paragraph now points to that checklist instead of "redo the versioning decision".
- Repo setting (no diff): tag ruleset `protect-ci-tags` id 22319727 created 2026-09-05 after owner GO — full `GET` output recorded in #116 (comment 5549437953).

## 完了記録 (Completion record)

candidate SHA: aa69c9b   (L1-8 superseding record: prior candidate 5ef2559 → delta commit aa69c9b after merge review r1; re-reviewed, all 3 seats cumulative GO)
implementer: Alpha (Claude Code / Fable 5.1) — docs only, direct edit (non-code)
reviewer: L1-9 design (5 seats, all GO-WITH-CHANGES, #116 comment 5549368272): GLM 5.3 / Grok 4.6 / Codex GPT-5.6 Sol / Gemini 3.8 Flash / Muse Spark 1.3. Merge review (S, docs, 3 seats): r1 GLM 5.3 / Grok 4.6 / Codex GPT-5.6 Sol all GO-WITH-CHANGES (PR comment 5549500395) → delta aa69c9b → all 3 cumulative GO, no new findings (PR comment below).
identity check: 別モデル（writer = Claude Fable; every seat is a non-Claude model — Opus deliberately not seated, L1-10）
CI: green at aa69c9b — `gh pr checks 153`: pass=11 skipping=2 fail=0 (Test + Lint / gitleaks / History Check / Risk Review Gate / PR Size / repository state all success, 2026-09-05 12:00 JST)
release: v0.27.0 — README is normative for adopters (ship-equivalent; docs-only is not an N/A excuse in a norms repo, T-5)
previous release: v0.26.0 → https://github.com/caty-ai/family-dev-handbook/releases/tag/v0.26.0 (fulfilled: annotated tag + GitHub Release, 2026-09-05)

### Done when → 結果

| Done when 項目 | 結果 | 証拠（コマンド or 手順 + 観測結果 + 日付） |
|---|---|---|
| ① `ci-v*` に tag protection / ruleset・作成/移動が admin/maintainer に限定 | PASS | `gh api -X POST repos/caty-ai/family-dev-handbook/rulesets --input ruleset.json` → 201, id 22319727, `enforcement: active`, `bypass_actors: [RepositoryRole 5 (admin), always]`, rules creation/update/deletion. Owner decision: admin only, no maintainer, no OrganizationAdmin. 2026-09-05 11:46 JST |
| ② 設定内容が実測で確認できる（出力を貼る） | PASS | `gh api repos/caty-ai/family-dev-handbook/rulesets/22319727` full JSON pasted in #116 comment 5549437953 (target tag / include `refs/tags/ci-v*` / 3 rules / bypass admin). List endpoint: `22319727 protect-ci-tags tag active`. `ci-v1` unchanged: `cdd6633` → `ae61ad5`. Negative probe from a write-role account: not run (no credential path available to Alpha) — evidence is configuration-level. 2026-09-05 |
| ③ README versioning 節に「`ci-v*` は保護タグ」明記 | PASS | `templates/ci/README.md` new subsection "### `ci-v*` は保護タグ — 作成・移動・削除は repository admin のみ" (this PR, 5ef2559 + aa69c9b). `make lint` → all PASS, `make test` → `suites: declared=6 executed=6 skipped=0`. 2026-09-05 |
| ④ write-path 変更時に `ci-v2` を切る方針の明文化 | PASS | Same subsection: "次のいずれかを含む改訂は `ci-v1` に流さず `ci-v2` を切る" with 3 reviewer-checkable items (permissions widening / release-sync checkout・execution・non-Release writes / new write-requiring reusable). Grok proposal adopted; wording sharpened per 5 design seats and widened to any write-path (not only `contents: write`) per 3 merge-review seats (aa69c9b). 2026-09-05 |
| テスト / lint green | PASS | `make lint` (mirror links, publication-gate selftest, gitleaks) PASS; `make test` suites 6/6 executed. 2026-09-05 |

### 宣言 vs 実 diff（L0-6）

git diff --stat origin/main...aa69c9b: `templates/ci/README.md | 32 +++++++++++++++++++++++++++++++-` (1 file, +31 −1)
宣言ファイル集合との差分: なし（WIP 宣言 = `templates/ci/README.md` のみ・ruleset はリポ設定で diff なし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
