### PR TITLE
chore(repo-state): pin caller to family-os v0.18.0 (family-os#163)

### DIFF
--- a/.github/workflows/repo-state.yml
+++ b/.github/workflows/repo-state.yml
@@ -17,7 +17,7 @@ concurrency:
 
 jobs:
   repo-state:
-    uses: caty-ai/family-os/.github/workflows/repo-state.yml@v0.12.1
+    uses: caty-ai/family-os/.github/workflows/repo-state.yml@v0.18.0
     secrets: inherit
     with:
-      generator_ref: v0.12.1
+      generator_ref: v0.18.0


### PR DESCRIPTION
## Why

Follow-up to caty-ai/family-os#163 (fix merged as family-os PR #166, released as [v0.18.0](https://github.com/caty-ai/family-os/releases/tag/v0.18.0)). Until this bump, this repo's `status.json.latest_tag` / `latest_release_url` never refreshed after a release-sync Release, because Releases created with `GITHUB_TOKEN` do not fire the `release` trigger and the pinned reusable workflow only refreshed on that event. v0.18.0 refreshes on every `update` run (push included).

## What (mechanical diff)

`.github/workflows/repo-state.yml`: `uses: …/repo-state.yml@v0.18.0` + `generator_ref: v0.18.0` (refs move together per the caller contract). Nothing else changes. The generator itself is unchanged since the current pin; only the reusable workflow's refresh gate moved.

Behaviour after merge: each `update` run makes one `gh api repos/{repo}/releases/latest` call with `GITHUB_TOKEN` (at most two with the rebase retry); a non-404 API failure fails that stamp run (fail-closed; readers detect the unstamped HEAD via SHA mismatch). The `pull_request` `check` job is unchanged. Details: family-os `docs/repo-state/spec.md` §2 / §4.

## Review

Batch of 13 caller bumps, one heterogeneous delta seat over the whole batch diff (the family-os#127 owner-approved lighter scheme for mechanical copies, cf. persona-engine#49). Seat record on caty-ai/family-os#163.

## 完了記録 (Completion record)

candidate SHA: f611e294322c608c7c2d519dc00f3db4be1cc3cb
implementer: Alpha (Claude Fable 5.1) — 2-line mechanical yml edit
reviewer: BATCH_SEAT
identity check: 別モデル
CI: see PR checks at merge time (recorded on family-os#163 per repo)
release: N/A ③ (CI wiring only — the caller pin; no behaviour, API or artifact of this repository changes)
previous release: unchanged by this PR (no ship-equivalent change here); ledger continues on this repo's next ship-equivalent lane

### Done when → 結果

| Done when 項目 | 結果 | 証拠 |
|---|---|---|
| Caller pins `repo-state.yml@v0.18.0` and `generator_ref: v0.18.0` | PASS | this diff (2 lines), 2026-09-05 |
| First `push` run on main after merge refreshes `latest_tag` to this repo's live latest Release | recorded on family-os#163 after merge | caller run + `status.json` diff |

Tracked in caty-ai/family-os#163.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
