### PR TITLE
feat(publication-gate): string-escape decode view in scan_views, verbatim from x-collector v0.3.3 (#154)

### DIFF
--- a/templates/publication-gate/README.md
+++ b/templates/publication-gate/README.md
@@ -204,6 +204,7 @@ Git mode なら publishable corpus から untrack する、または suffix 追�
 summary は必ず `enumeration: git` または `enumeration: rglob-fallback` と、
 `denylist rules loaded : N` を表示する。raw view の hit は raw text の行番号を使い、percent/HTML decode 後に
 初めて見つかった hit は decoded text の行番号と `(decoded view)` marker を表示する。
+scan views は各 percent/HTML view から JSON/YAML string-escape decode（`\uXXXX` / `\UXXXXXXXX` / `\xHH` / `\/`、surrogate pair は結合し、lone/invalid escape は verbatim のまま）も最大 3 fixed-point rounds 導出し、3 rounds より深い nesting は documented boundary とする（出典: x-collector#77, v0.3.3）。
 
 `--selftest` の violating corpus、clean twin、sample denylist は checker 自体の string constants として
 埋め込まれている。disk 上の `fixtures/` は人間向け資料であり selftest の依存ではないため、checker の

--- a/templates/publication-gate/README.md
+++ b/templates/publication-gate/README.md
@@ -204,7 +204,9 @@ Git mode なら publishable corpus から untrack する、または suffix 追�
 summary は必ず `enumeration: git` または `enumeration: rglob-fallback` と、
 `denylist rules loaded : N` を表示する。raw view の hit は raw text の行番号を使い、percent/HTML decode 後に
 初めて見つかった hit は decoded text の行番号と `(decoded view)` marker を表示する。
-scan views は各 percent/HTML view から JSON/YAML string-escape decode（`\uXXXX` / `\UXXXXXXXX` / `\xHH` / `\/`、surrogate pair は結合し、lone/invalid escape は verbatim のまま）も最大 3 fixed-point rounds 導出し、3 rounds より深い nesting は documented boundary とする（出典: x-collector#77, v0.3.3）。
+scan views は raw view と各 percent/HTML view から JSON/YAML string-escape decode（`\uXXXX` / `\UXXXXXXXX` /
+`\xHH` / `\/`、surrogate pair は結合し、lone/invalid escape は verbatim のまま）も最大 3 fixed-point rounds
+導出し、3 rounds より深い nesting は documented boundary とする（出典: x-collector#77, v0.3.3）。
 
 `--selftest` の violating corpus、clean twin、sample denylist は checker 自体の string constants として
 埋め込まれている。disk 上の `fixtures/` は人間向け資料であり selftest の依存ではないため、checker の

--- a/templates/publication-gate/check_publication_gate.py
+++ b/templates/publication-gate/check_publication_gate.py
@@ -76,8 +76,50 @@ def language_of(path):
     return match.group("lang") if match else "en"
 
 
+STRING_ESCAPE = re.compile(
+    r"\\u([dD][89AaBb][0-9A-Fa-f]{2})\\u([dD][c-fC-F][0-9A-Fa-f]{2})"
+    r"|\\u([0-9A-Fa-f]{4})"
+    r"|\\U([0-9A-Fa-f]{8})"
+    r"|\\x([0-9A-Fa-f]{2})"
+    r"|\\/"
+)
+
+
+def decode_string_escapes(text):
+    """Decode path-relevant JSON/YAML escapes once, without tokenizing strings.
+
+    Backslash, quote, newline/tab, octal, named, and null escapes stay verbatim:
+    path rules already tolerate repeated backslashes and do not depend on quotes
+    or controls. Nested serialisation (JSON in JSON, ``\\\\u002f``, ``\\u002f``)
+    is resolved by the bounded rounds in :func:`scan_views`; depth beyond three
+    rounds is the documented boundary.
+    """
+
+    def replace(match):
+        if match.group(1) is not None:
+            high = int(match.group(1), 16)
+            low = int(match.group(2), 16)
+            return chr(0x10000 + ((high - 0xD800) << 10) + low - 0xDC00)
+        if match.group(3) is not None:
+            value = int(match.group(3), 16)
+            return match.group(0) if 0xD800 <= value <= 0xDFFF else chr(value)
+        if match.group(4) is not None:
+            value = int(match.group(4), 16)
+            if value > 0x10FFFF or 0xD800 <= value <= 0xDFFF:
+                return match.group(0)
+            return chr(value)
+        if match.group(5) is not None:
+            return chr(int(match.group(5), 16))
+        return "/"
+
+    return STRING_ESCAPE.sub(replace, text)
+
+
 def scan_views(text):
-    """Return raw plus iterative percent/HTML-decoded views."""
+    """Return raw plus iterative percent/HTML-decoded views, then up to three
+    string-escape rounds per view (``\\uXXXX``, ``\\UXXXXXXXX``, ``\\xHH``,
+    ``\\/``), stopping at the fixed point — #77.
+    """
     views = [text]
     current = text
     for _ in range(3):
@@ -90,6 +132,15 @@ def scan_views(text):
         if unescaped == current:
             break
         current = unescaped
+    for view in tuple(views):
+        current = view
+        for _ in range(3):
+            decoded = decode_string_escapes(current)
+            if decoded == current:
+                break
+            if decoded not in views:
+                views.append(decoded)
+            current = decoded
     return tuple(views)
 
 
@@ -932,6 +983,126 @@ def selftest_scanners():
         check_denylist(documents, rules, failures) == 1
         and "(decoded view)" in failures[0],
         "decoded denylist marker",
+    )
+    unicode_escape_failures = []
+    _selftest_check(
+        check_denylist(
+            {"README.md": "private\\u002dmarker\n"}, rules, unicode_escape_failures
+        )
+        == 1
+        and "(decoded view)" in unicode_escape_failures[0],
+        "string-escape unicode denylist marker",
+    )
+    long_unicode_escape_failures = []
+    _selftest_check(
+        check_denylist(
+            {"README.md": "private\\U0000002dmarker\n"},
+            rules,
+            long_unicode_escape_failures,
+        )
+        == 1
+        and "(decoded view)" in long_unicode_escape_failures[0],
+        "string-escape long-unicode denylist marker",
+    )
+    hex_escape_failures = []
+    _selftest_check(
+        check_denylist(
+            {"README.md": "private\\x2dmarker\n"}, rules, hex_escape_failures
+        )
+        == 1
+        and "(decoded view)" in hex_escape_failures[0],
+        "string-escape hex denylist marker",
+    )
+    wrapped_escape_failures = []
+    _selftest_check(
+        check_denylist(
+            {"README.md": "private%5Cu002dmarker\n"}, rules, wrapped_escape_failures
+        )
+        == 1
+        and "(decoded view)" in wrapped_escape_failures[0],
+        "string-escape percent-wrapped denylist marker",
+    )
+    entity_wrapped_escape_failures = []
+    _selftest_check(
+        check_denylist(
+            {"README.md": "private&#92;u002dmarker\n"},
+            rules,
+            entity_wrapped_escape_failures,
+        )
+        == 1
+        and "(decoded view)" in entity_wrapped_escape_failures[0],
+        "string-escape entity-wrapped denylist marker",
+    )
+    escape_line_failures = []
+    _selftest_check(
+        check_denylist(
+            {"README.md": "safe\\u000aprivate\\u002dmarker\n"},
+            rules,
+            escape_line_failures,
+        )
+        == 1
+        and escape_line_failures
+        == ["denylist: README.md:2 contains private marker (decoded view)"],
+        "string-escape decoded-view line number",
+    )
+    surrogate_neighbour_failures = []
+    _selftest_check(
+        check_denylist(
+            {"README.md": "\\ud83d\\ude00 private\\u002dmarker"},
+            rules,
+            surrogate_neighbour_failures,
+        )
+        == 1
+        and "(decoded view)" in surrogate_neighbour_failures[0],
+        "string-escape surrogate pair preserves neighbouring match",
+    )
+    _selftest_check(
+        "😀" in scan_views("\\ud83d\\ude00"),
+        "string-escape surrogate pair combines",
+    )
+    lone_surrogate_views = scan_views("\\ud83d x")
+    _selftest_check(
+        "\\ud83d x" in lone_surrogate_views
+        and not any(
+            0xD800 <= ord(character) <= 0xDFFF
+            for view in lone_surrogate_views
+            for character in view
+        ),
+        "string-escape lone surrogate remains verbatim",
+    )
+    _selftest_check(
+        scan_views("\\U7FFFFFFF \\udc00 \\ud83d")
+        == ("\\U7FFFFFFF \\udc00 \\ud83d",),
+        "string-escape invalid code points remain verbatim",
+    )
+    _selftest_check(
+        scan_views("\\U002f") == ("\\U002f",),
+        "string-escape short uppercase escape remains verbatim",
+    )
+    _selftest_check(
+        scan_views("plain text") == ("plain text",),
+        "string-escape plain text view dedup",
+    )
+    _selftest_check(
+        "-" in scan_views("\\u005cu002d"),
+        "string-escape nested serialisation fixed point",
+    )
+    _selftest_check(
+        "-" in scan_views("\\u005cu005cu002d"),
+        "string-escape three rounds suffice",
+    )
+    _selftest_check(
+        "-" not in scan_views("\\u005cu005cu005cu002d"),
+        "string-escape depth boundary",
+    )
+    _selftest_check(
+        scan_views("\\u005cu005cu005cu002d")[-1] == "\\u002d",
+        "string-escape depth boundary last view",
+    )
+    _selftest_check(
+        scan_views("private%2Dmarker")[:2]
+        == ("private%2Dmarker", "private-marker"),
+        "string-escape existing view order",
     )
     raw_line_failures = []
     _selftest_check(


### PR DESCRIPTION
Closes #154

## Why
`scan_views()` in the family publication-gate template only decoded percent and HTML-entity encodings, so a personal path spelled with JSON/YAML string escapes (`\u002fUsers\u002falice`, `C:\u005cUsers\u005calice`, `\/Users\/alice`, JSON-in-JSON `\\\/Users\\\/alice`) passed every path rule a downstream repo ships. The lead lane caty-ai/x-collector#77 fixed and froze this in v0.3.3 after a 5-seat release-gate review. Downstream repos re-copy this template verbatim (`git show <tag>:templates/publication-gate/check_publication_gate.py`), so the fix has to land here before family-os#164 re-copies.

## What
Verbatim port of the frozen v0.3.3 blocks (byte-identical, proven by `verify_verbatim.py`: decode block 68 lines + selftest vector block 120 lines):
- module-level `STRING_ESCAPE` + `decode_string_escapes()`: one-pass decode of `\uXXXX` (surrogate pairs combined, lone surrogates verbatim), `\UXXXXXXXX` (≤ U+10FFFF, non-surrogate), `\xHH`, `\/`. Nothing else is decoded.
- `scan_views()`: after the percent/HTML loop, up to **three fixed-point rounds** of the decoder on each existing view; existing views keep their indices; escape views are not re-fed into percent/HTML decoding; depth > 3 is the documented boundary.
- `selftest_scanners`: the 17 generic string-escape vectors for the fixture rule (151 → 168 assertions). Shipped-rule canaries stay downstream (the template ships no denylist) — list for the re-copy note: `\u002f`, `\/`, `\u005c`, nested PHP form, `\u005cu002f`, `\\u002f` + the clean-control block.
- README: one sentence (hard-wrapped) documenting the string-escape view, the three-round boundary and the origin.

No `docs/**` change (PR #153 owned that lane and has merged; this branch is rebased on it).

## Completion record (L1-7)
- Candidate SHA: ea8253226d8e71d6d5175a5376c6201dc7a09d45 (base efaeb28 = origin/main at rebase; first candidate e3a5b67 on f98e2dd, rebased without conflict before review)
- Implementer: Codex gpt-5.6 (profile sol, workspace-write, via sitter-run). Brief / inspection / commit: Alpha (no vote). Alpha direct edits: none.
- Reviewers requested (`loom-seats --size M --risk release-gate`, 5 heterogeneous seats, publication-gate = high-risk): opus-5 / glm-5.3 / grok-4.6 / kimi-k3 / codex-sol. kimi-k3 absent (weekly quota 403, probed) → deterministic substitute gemini-3.8-flash; gemini headless seat auto-denied shell tools (no probes possible) → next deterministic substitute muse-spark-1.3 (`loom-seats --absent kimi-k3 --absent gemini-3.8-flash`).
- Reviewers actual:

  | seat | round 1 (990e9a2) | delta 1 (ea82532, README-only) |
  |---|---|---|
  | opus-5 | GO (2 NIT: README line length / "raw view" wording; INFO notes) | GO (both NITs resolved, no new findings) |
  | codex gpt-5.6-sol (self-reported "gpt-6-astra"; sitter log header = gpt-5.6-sol) | GO (no findings) | not re-seated (no code change) |
  | glm-5.3 | GO (NIT: mixed-separator `/Users\alice` matches no rule — pre-existing denylist shape, downstream note; NIT "raw view" wording) | GO (no new findings) |
  | grok-4.6 | GO (no findings) | GO (no new findings) |
  | muse-spark-1.3 (substitute) | GO (no findings) | not re-seated (no code change) |

  Seat records: `~/claude-workspace/_handoffs/handbook-154-review-20260905/seats/`.

- Identity check: commit authored as `shojikumaru <184229851+shojikumaru@users.noreply.github.com>` (worktree config), gitleaks pre-commit clean.
- CI: all green on ea82532 (gitleaks / history-check / pr-size / repo-state / risk-review-gate ×3 / test-lint lint+test+test-macos / watch — https://github.com/caty-ai/family-dev-handbook/pull/156/checks)
- Release: **v0.28.0 (measured before tagging: latest release v0.27.0)** after merge (template behaviour changes → 出荷相当; family-os#164 pins this tag). Previous release: v0.27.0 — https://github.com/caty-ai/family-dev-handbook/releases/tag/v0.27.0 (#116, fulfilled).
- Effective file set vs WIP declaration: `templates/publication-gate/check_publication_gate.py`, `templates/publication-gate/README.md` — `git diff --stat origin/main...ea8253226d8e71d6d5175a5376c6201dc7a09d45` = 2 files. Matches.

## Done when
| item | status | evidence (2026-09-05) |
|---|---|---|
| `STRING_ESCAPE` + `decode_string_escapes` + three-round loop adopted verbatim; existing view order unchanged | PASS | `verify_verbatim.py` → `decode block: VERBATIM (68 lines)` / `selftest string-escape vectors: VERBATIM (120 lines)` exit 0; assertion `string-escape existing view order` pins `scan_views("private%2Dmarker")[:2]` |
| Template selftest gains the generic string-escape vectors | PASS | `--selftest` → `PASS (publication gate selftest; assertions: 168)` (was 151; +17 = number of `_selftest_check(` calls in the inserted block); all 51 pre-existing assertion messages present unchanged |
| Leak literals written split | N/A (closed reason: the inserted block spells no user path; no new literal added) | `git diff` contains no `/Users` / `C:\Users` literal |
| Mutation-verified | PASS | scratch copies: loop removed → `string-escape unicode denylist marker` red; `range(1)` → `string-escape nested serialisation fixed point` red; `range(2)` → `string-escape three rounds suffice` red; `range(4)` → `string-escape depth boundary` red; worktree file green after |
| `make test` green; README one line | PASS | `make test` → `suites: declared=6 executed=6 skipped=0` exit 0 (re-run on the final head); README gains one sentence (round 1: one 266-char physical line; delta 1 hard-wrapped it to three physical lines and named the raw view, per opus-5/glm-5.3 NITs) — `git diff --stat` README `3 +` |
| Heterogeneous review seated for the high-risk area | PASS | table above |
| No new false positives on a real corpus | PASS | live gate on this repository with the x-collector denylist (5 rules incl. three user-path rules): `OK — publication gate passed`, `denylist matches : 0` (baseline on f98e2dd identical) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
