### PR TITLE
feat(publication-gate): ship the family personal-path denylist block (5 rules) in the sample (#157)

### DIFF
--- a/templates/publication-gate/README.md
+++ b/templates/publication-gate/README.md
@@ -111,6 +111,15 @@ NAME<TAB>REGEX
 `.publication-denylist` は e-mail ルールを**必ず**含めること（sample には `email-address` ルールを同梱。
 sample を使わず自前 denylist を書く場合も同等のルールを載せる）。
 
+個人パス（ホームディレクトリ）の検出は family 推奨セットとして 5 ルール
+（`local-user-path` / `windows-user-path` / `wsl-drvfs-user-path` / `wsl-unc-linux-home` / `host-mount-user-path`）を
+sample に同梱している。x-collector v0.3.4 の `.publication-denylist` から verbatim で、family-os / meetmate は先頭ルールを
+`absolute-personal-path` の名前で持つ（regex は同一）。形の要点は**先頭アンカーを置かない**こと（`^` や lookbehind は
+UNC・`vscode-remote://`・`file://localhost/`・相対パスの綴りで fail-open する）と、`local-user-path` だけが `(?-i:` で
+case-sensitive なこと（`api.github.com/users/...` の誤検知回避）。意図的に見送った 2 クラス（`/mnt` 以外のルートの
+`/c/users/<name>`、複数文字マウント名の `/mnt/cdrive/users/<name>`）とその理由は sample のコメントに記録してあり、
+採用リポは 5 行をそのままコピーし、変える場合は理由を決定として残す。
+
 denylist は検出すべき禁止リテラルを必然的に含む。そのため checker は、スキャン対象から
 既定の `<root>/.publication-denylist`、または `--denylist` で明示したファイルが root 内にある場合は
 そのファイルを**パスで**自己除外する。この path-exclusion は、拡張子 allowlist を廃止して全 regular file を

--- a/templates/publication-gate/check_publication_gate.py
+++ b/templates/publication-gate/check_publication_gate.py
@@ -813,6 +813,34 @@ SELFTEST_SAMPLE_DENYLIST = (
     "private-host\tprivate\\.example\\.invalid\n"
     "# Keep local@host/... coverage in denylist territory.\n"
     "email-address\t\\b[A-Z0-9._%+\\-]+@[A-Z0-9.\\-]+\\.[A-Z]{2,}\\b\n"
+    "# --- family 推奨: 個人パス 5 ルール（x-collector v0.3.4 の .publication-denylist から verbatim・#71→#75→#76→#78）---\n"
+    "# family shape（#76 の異種5席裁定・#78 で凍結）:\n"
+    "#   先頭アンカーなし。^ や lookbehind を付けると \\\\wsl.localhost\\<distro>\\..., vscode-remote://wsl+<distro>/...,\n"
+    "#   file://localhost/..., sftp://..., 相対の ../ や省略の .../ の綴りで fail-open する。\n"
+    "#   最初の区切りは [\\\\/] 1個、区切り間は [\\\\/]+（JSON の \\\\\\\\ と \\/ を吸収）。ドライブ文字は [A-Za-z] 1文字だけ。\n"
+    "#   (?![<{]) で <name> / {name} のプレースホルダを除外。名前は [\\w.-]+（re.ASCII なし・CJK 名も対象）。\n"
+    "#   ルールは re.IGNORECASE で照合されるが local-user-path だけ (?-i: で case-sensitive\n"
+    "#   （api.github.com/users/... の誤検知クラスを避ける）。family-os / meetmate は同じ regex を absolute-personal-path の名前で持つ。\n"
+    "# 見送り（won't-fix・理由ごと持ち運ぶ）:\n"
+    "#   /c/users/<name>（WSL automount.root=/ や Git-Bash MSYS など /mnt 以外のルート）: 裸の /<letter>/users/ アンカーは\n"
+    "#     family gate script 自身の selftest canary に 390 件自己検知して全ゲートが赤になる。先頭 lookbehind 版は corpus 0 件だが\n"
+    "#     vscode-remote://wsl+<distro>/c/users/<name>・sftp://<host>/c/users/<name>・https://<host>/c/users/<name>・\n"
+    "#     file://localhost/c/users/<name> の host 付き綴りで fail-open する。ツール出力の大文字綴り（/c/ の後に Users/<name>）は\n"
+    "#     local-user-path が拾う。\n"
+    "#   /mnt/cdrive/users/<name>（複数文字のマウント名）: ドライブ文字を [A-Za-z]+ に広げると /mnt/backup/users/shared や\n"
+    "#     /mnt/wsl/users/foo に当たる（#76 の trade）。\n"
+    "local-user-path\t(?-i:/Use" "rs/|/home/(?![<{])[A-Za-z0-9._-]+)\n"
+    "windows-user-path\t\\b[A-Za-z]:[\\\\/]+Users[\\\\/]+(?![<{])[\\w.-]+\n"
+    "wsl-drvfs-user-path\t[\\\\/]mnt[\\\\/]+[A-Za-z][\\\\/]+users[\\\\/]+(?![<{])[\\w.-]+\n"
+    "wsl-unc-linux-home\twsl(?:\\$|\\.localhost)[\\\\/]+[^\\\\/\\s]+[\\\\/]+home[\\\\/]+(?![<{])[\\w.-]+\n"
+    "host-mount-user-path\t[\\\\/](?:cygdrive|host_mnt|mnt[\\\\/]+[\\w.-]+)[\\\\/]+[A-Za-z][\\\\/]+users[\\\\/]+(?![<{])[\\w.-]+\n"
+)
+SELFTEST_SAMPLE_PATH_CANARIES = (
+    ("local-user-path", "/Use" "rs/alice"),
+    ("windows-user-path", "C:\\Use" "rs\\alice"),
+    ("wsl-drvfs-user-path", "/mnt/c/use" "rs/alice"),
+    ("wsl-unc-linux-home", "\\\\wsl$\\Ubuntu\\ho" "me\\alice"),
+    ("host-mount-user-path", "/cygdri" "ve/c/users/alice"),
 )
 SELFTEST_CLEAN_README = "# Public project\n\nPublication-safe example content.\n"
 SELFTEST_VIOLATING_README = (
@@ -917,6 +945,37 @@ def selftest_policy_parsers():
             _selftest_check(
                 shipped_sample.read_bytes() == SELFTEST_SAMPLE_DENYLIST.encode("utf-8"),
                 "shipped sample denylist stays byte-identical",
+            )
+        (root / DENYLIST_NAME).write_text(SELFTEST_SAMPLE_DENYLIST, encoding="utf-8")
+        sample_rules = load_denylist(root)
+        sample_patterns = dict(sample_rules)
+        for name, _ in SELFTEST_SAMPLE_PATH_CANARIES:
+            _selftest_check(
+                name in sample_patterns,
+                "shipped sample path canary rule loaded: %s" % name,
+            )
+        _selftest_check(len(sample_rules) == 8, "shipped sample denylist loads eight rules")
+        for name, canary in SELFTEST_SAMPLE_PATH_CANARIES:
+            _selftest_check(
+                sample_patterns[name].search(canary) is not None,
+                "shipped sample path canary hits %s" % name,
+            )
+        for clean in (
+            "/mnt/backup/users/shared",
+            "mailto:Users/alice",
+            "api.github." "com/users/alice",
+        ):
+            _selftest_check(
+                all(pattern.search(clean) is None for _, pattern in sample_rules),
+                "shipped sample path clean control: %s" % clean,
+            )
+        for name, canary in SELFTEST_SAMPLE_PATH_CANARIES:
+            remaining_rules = tuple(
+                rule for rule in sample_rules if rule[0] != name
+            )
+            _selftest_check(
+                all(pattern.search(canary) is None for _, pattern in remaining_rules),
+                "shipped sample path canary requires %s" % name,
             )
         _selftest_check(load_label_whitelist(root) == frozenset(), "absent whitelist")
         (root / WHITELIST_NAME).write_text("README.md\tapproved exact line\n", encoding="utf-8")
@@ -2244,10 +2303,28 @@ def selftest_end_to_end():
         )
         _selftest_check(
             status == 1
-            and "denylist rules loaded : 3" in output
+            and "denylist rules loaded : 8" in output
             and "denylist: README.md:1 contains email-address" in output,
             "shipped sample denylist catches slug-domain email fixture: %r" % output,
         )
+
+    for name, canary in SELFTEST_SAMPLE_PATH_CANARIES:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            _materialize_fixture(
+                root,
+                "See " + canary + "\n",
+                SELFTEST_SAMPLE_DENYLIST,
+            )
+            status, output = _capture_main(
+                ["--root", str(root), "--account-slug", "neutral-owner", "--no-registry"]
+            )
+            _selftest_check(
+                status == 1
+                and "denylist: README.md:1 contains " + name in output
+                and "denylist rules loaded : 8" in output,
+                "shipped sample path canary reaches main for %s: %r" % (name, output),
+            )
 
     with tempfile.TemporaryDirectory() as temporary:
         root = Path(temporary)

--- a/templates/publication-gate/fixtures/sample.publication-denylist
+++ b/templates/publication-gate/fixtures/sample.publication-denylist
@@ -3,3 +3,24 @@ private-marker	acme[-_ ]secret
 private-host	private\.example\.invalid
 # Keep local@host/... coverage in denylist territory.
 email-address	\b[A-Z0-9._%+\-]+@[A-Z0-9.\-]+\.[A-Z]{2,}\b
+# --- family 推奨: 個人パス 5 ルール（x-collector v0.3.4 の .publication-denylist から verbatim・#71→#75→#76→#78）---
+# family shape（#76 の異種5席裁定・#78 で凍結）:
+#   先頭アンカーなし。^ や lookbehind を付けると \\wsl.localhost\<distro>\..., vscode-remote://wsl+<distro>/...,
+#   file://localhost/..., sftp://..., 相対の ../ や省略の .../ の綴りで fail-open する。
+#   最初の区切りは [\\/] 1個、区切り間は [\\/]+（JSON の \\\\ と \/ を吸収）。ドライブ文字は [A-Za-z] 1文字だけ。
+#   (?![<{]) で <name> / {name} のプレースホルダを除外。名前は [\w.-]+（re.ASCII なし・CJK 名も対象）。
+#   ルールは re.IGNORECASE で照合されるが local-user-path だけ (?-i: で case-sensitive
+#   （api.github.com/users/... の誤検知クラスを避ける）。family-os / meetmate は同じ regex を absolute-personal-path の名前で持つ。
+# 見送り（won't-fix・理由ごと持ち運ぶ）:
+#   /c/users/<name>（WSL automount.root=/ や Git-Bash MSYS など /mnt 以外のルート）: 裸の /<letter>/users/ アンカーは
+#     family gate script 自身の selftest canary に 390 件自己検知して全ゲートが赤になる。先頭 lookbehind 版は corpus 0 件だが
+#     vscode-remote://wsl+<distro>/c/users/<name>・sftp://<host>/c/users/<name>・https://<host>/c/users/<name>・
+#     file://localhost/c/users/<name> の host 付き綴りで fail-open する。ツール出力の大文字綴り（/c/ の後に Users/<name>）は
+#     local-user-path が拾う。
+#   /mnt/cdrive/users/<name>（複数文字のマウント名）: ドライブ文字を [A-Za-z]+ に広げると /mnt/backup/users/shared や
+#     /mnt/wsl/users/foo に当たる（#76 の trade）。
+local-user-path	(?-i:/Users/|/home/(?![<{])[A-Za-z0-9._-]+)
+windows-user-path	\b[A-Za-z]:[\\/]+Users[\\/]+(?![<{])[\w.-]+
+wsl-drvfs-user-path	[\\/]mnt[\\/]+[A-Za-z][\\/]+users[\\/]+(?![<{])[\w.-]+
+wsl-unc-linux-home	wsl(?:\$|\.localhost)[\\/]+[^\\/\s]+[\\/]+home[\\/]+(?![<{])[\w.-]+
+host-mount-user-path	[\\/](?:cygdrive|host_mnt|mnt[\\/]+[\w.-]+)[\\/]+[A-Za-z][\\/]+users[\\/]+(?![<{])[\w.-]+


### PR DESCRIPTION
## Summary

The template sample denylist shipped three fixture rules and no personal-path rule, while every downstream family repo (x-collector, family-os, meetmate) carries the same five-rule personal-path block frozen lane by lane in x-collector#71 → #75 → #76 → #78. This ships that block in the template so the next adopter starts from it instead of rediscovering the class, and carries the recorded won't-fix classes (with their reasons) in the artifact that gets copied.

- `templates/publication-gate/fixtures/sample.publication-denylist`: the five rules verbatim from x-collector v0.3.4 (`local-user-path` / `windows-user-path` / `wsl-drvfs-user-path` / `wsl-unc-linux-home` / `host-mount-user-path`) plus a Japanese comment block: family shape (no leading anchor, `[\\/]` separators, single drive letter, `(?![<{])` placeholder exclusion, case-sensitive `local-user-path`; family-os / meetmate name the first rule `absolute-personal-path`, regex identical) and the two won't-fix classes (`/c/users/<name>` outside `/mnt`: 390 selftest self-hits for the bare anchor, lookbehind fails open on host-prefixed spellings; `/mnt/cdrive/users/<name>`: widening the drive class hits `/mnt/backup/users/shared`, #76 trade).
- `templates/publication-gate/check_publication_gate.py`: `SELFTEST_SAMPLE_DENYLIST` re-synced byte-identically (the `/Users/` literal is split in the source so the template's own gate does not self-trip); new `SELFTEST_SAMPLE_PATH_CANARIES`; in `selftest_policy_parsers`: 5 rule names present, 8 rules loaded, one split HIT canary per rule, 3 clean controls matched by no rule, per-rule mutation proof; in `selftest_end_to_end`: each canary caught through the real scan path with `denylist rules loaded : 8`; the old `rules loaded : 3` assertion for the sample becomes `8`. No gate-logic change.
- `templates/publication-gate/README.md`: one paragraph in §「`.publication-denylist` の正確な形式」 pointing at the block as the family recommended set, the no-leading-anchor rule, the case-sensitive exception, and where the won't-fix record lives.

Adopter note (Opus seat, P3, same class as the existing `violating-repo` fixture): the sample now contains an unsplit `/Users/` detection literal, so an adopter who vendors the whole `templates/publication-gate/` directory including `fixtures/` and then adopts the five rules will see `fixtures/sample.publication-denylist:22 contains local-user-path` on their own tree. The documented adoption path (copy the file to the repo root as `.publication-denylist`, README step list) is path-excluded and unaffected.

Closes #157
Refs caty-ai/x-collector#78, caty-ai/family-os#168, caty-ai/meetmate#207

## Declared files

- `templates/publication-gate/fixtures/sample.publication-denylist`
- `templates/publication-gate/check_publication_gate.py` (constant + selftest only)
- `templates/publication-gate/README.md`

`docs/**`, `.github/**`, `i18n/**`, `scripts/**`, `Makefile` untouched.

## 完了記録 (Completion record)

candidate SHA: 8319782 (single commit; r1 = 5/5 GO with zero blocking findings, no delta)
implementer: Codex GPT-5.6 Sol (`codex exec --profile sol --sandbox workspace-write`, sitter-run ledger) — design/brief/adjudication/commit by alpha (Claude Code, Fable 5.1); alpha is not a seat
reviewer: 5 heterogeneous seats (publication-gate = high-risk area): Opus 5 (code-reviewer Agent) / Kimi K3 (`kimi -p`) / Codex GPT-5.6 Sol (`codex exec`, isolated cwd, same-family seat authorized for writer=codex-sol per review_council 2026-08-12) / Qwen 3.8 Max (`qwen -p`) / Gemini 3.8 Flash (agy, static) — r1 5/5 GO (record below)
identity check: 別モデル（writer = Codex Sol; four of five seats are non-Codex, the Codex seat ran in a fresh isolated context and is the recorded same-family exception: scope=this panel / pair=codex-sol writer+seat / reason=review_council 2026-08-12 five-seat revision / approved_by=owner decision 2026-08-12 / date=2026-09-08 / writer condition=codex-sol only）
CI: on 8319782 — gitleaks, history-check, pr-size (109 lines, no exemption needed), repo-state, risk-review-gate (detect-risk-paths / apply-visibility-labels / risk-review-gate), test-lint (lint / test / test-macos), watch: all SUCCESS (2026-09-08)
release: v0.30.0（配布物 `templates/publication-gate/**` の同梱物が変わり下流が tag で再コピーする = 出荷相当。additive → MINOR）
previous release: v0.29.0 → https://github.com/caty-ai/family-dev-handbook/releases/tag/v0.29.0（履行済み: Release 実在・2026-09-07）

| Done when | 結果 | 証拠 |
|---|---|---|
| sample carries the five-rule block with a comment block stating the family shape and the two won't-fix classes with reasons (Japanese, existing comment style, no real names) | PASS | five `NAME<TAB>REGEX` lines diffed against `git -C x-collector show v0.3.4:.publication-denylist` (non-comment, non-`internal-*` lines) → empty diff (2026-09-08); comment block lines 6–21 of the sample; seats grepped the diff for real names/hosts → none |
| README §「`.publication-denylist` の正確な形式」 gains a short paragraph (block = family recommended set, no-leading-anchor rule) | PASS | one paragraph at README.md:114–122, inside the section (header :89, next header :132) (2026-09-08) |
| …with the i18n copies (`i18n/en`, `i18n/th`, `i18n/zh`) updated in the same PR | N/A（実測: 鏡像が存在しない） | `find i18n -path '*publication-gate*'` → empty; `i18n/{en,th,zh}/templates/` mirror only `publication-checklist.md`, which this PR does not touch (verified independently by Opus / Kimi / Codex / Qwen seats, 2026-09-08) |
| template selftest gains one canary per new rule against the sample, split so the template's own gate does not self-trip | PASS | `python3 -B templates/publication-gate/check_publication_gate.py --selftest` → `PASS (publication gate selftest; assertions: 192)` (baseline 168); self-gate `--root . --account-slug shojikumaru --no-registry --denylist templates/publication-gate/fixtures/sample.publication-denylist` → `denylist rules loaded : 8`, `FAILED (1)` = pre-existing `violating-repo/README.fixture:3 contains private-marker` only, no hit from the five new rules; `grep -n '/Users/' check_publication_gate.py README.md` → empty (2026-09-08) |
| mutation is load-bearing | PASS | scratch copies of `templates/publication-gate/`: deleting each of the five rule lines from both sample and constant → `--selftest` exit 1 `selftest failed: shipped sample path canary rule loaded: <rule>` (5/5 named); deleting from the sample only → `selftest failed: shipped sample denylist stays byte-identical`; unmodified copy → PASS 192 (2026-09-08) |
| downstream repos referenced for traceability | PASS | Refs above; one-line "upstreamed in handbook <tag>" comment to x-collector#78 / family-os#168 / meetmate#207 after the Release exists (MERGED comment will link them) |
| heterogeneous review seated (high-risk area); ci-v* discipline if reusable workflows touched | PASS | 5 seats, r1 5/5 GO (record below); `git diff --name-only origin/main...8319782` = the three declared files, `.github/**` untouched (2026-09-08) |

Local (worktree, 2026-09-08): `make test` → 6 suites PASS, `suites: declared=6 executed=6 skipped=0`; `git diff --stat origin/main...8319782` → `3 files changed, 108 insertions(+), 1 deletion(-)`.

## Review record

Panel: `loom-seats --size M --risk release-gate --absent glm-5.3 --absent grok-4.6` → opus-5 / kimi-k3 / qwen3.8-max / gemini-3.8-flash / codex-sol (GLM 5.3 429 weekly limit until 2026-09-10; Grok 4.6 402 balance exhausted; fable-5 not used per policy). Blind r1 on one identical packet (`_handoffs/handbook-157-review-20260908/packet-157-r1.md`), read-only, each seat asked to check the named worst failure shapes F1 regex drift / F2 constant-sample desync / F3 self-trip / F4 mutation not load-bearing / F5 scope-hygiene with commands.

**r1 — candidate 8319782**

| seat | requested → actual | verdict | blocking | F1..F5 | evidence highlights |
|---|---|---|---|---|---|
| Opus 5 (code-reviewer Agent) | opus-5 → claude-opus-5 | GO | 0 | ok ok ok ok ok | 5 regexes parsed and compared = all MATCH; byte check load-bearing (1-byte drift → red; `fixtures/` removed → 191, new canaries unconditional); self-gate 138 files, 1 pre-existing failure; mutation on two rules red naming the rule; 17-spelling probe of the comment's claims = 0 mismatches. P3 ×3: vendored-`fixtures/` adopter self-trip (recorded above), Issue prose "three classes" vs two enumerated won't-fix bullets (PR ships the enumerated two), pre-existing `is_file()` guard on the byte check |
| Kimi K3 (`kimi -p`) | kimi-k3 → Kimi Code CLI | GO | 0 | ok ok ok ok ok | byte-compare of rule lines and of constant vs sample (2477 == 2477); selftest 192; self-gate 8 rules / 1 pre-existing failure; scratch mutation red naming `wsl-drvfs-user-path`; 6 clean/won't-fix probes clean; won't-fix wording cross-read against Issue #157. No findings |
| Codex GPT-5.6 Sol (`codex exec`, isolated cwd) | gpt-5.6-sol → gpt-5.6-sol (sitter header) | GO | 0 | ok ok ok ok ok | AST-evaluated constant vs fixture bytes: SHA-256 `7b78b317…` both sides; `git diff --check` clean; self-gate 1 pre-existing failure; scratch mutation red naming the rule; `make test` 6/6; won't-fix wording checked against x-collector 258033e / v0.3.4 provenance (GitHub unreachable from sandbox). No findings |
| Qwen 3.8 Max (`qwen -p`) | qwen3.8-max → Qwen (id not exposed) | GO | 0 | ok ok ok ok ok | sorted rule-line md5 equal both sides; constant SHA-256 == sample; selftest 192; self-gate 1 pre-existing failure; three scratch probes (two rules + sample-only) red as expected; verified family-os / meetmate `absolute-personal-path` regex identical; clean-control reasoning per rule. No findings |
| Gemini 3.8 Flash (agy, static, no tools) | gemini-3.8-flash → Gemini 3.8 Flash (High) | GO | 0 | ok ok ok ok ok | character-level comparison of the five rules against the inlined frozen block; traced the split literals and clean controls by reasoning; won't-fix wording matches #76/#78. No findings |

Adjudication r1 (alpha): 5/5 GO, zero blocking findings across all seats; the one substantive P3 (vendored-fixtures self-trip) is recorded in the Summary for adopters and is the same pre-existing class as the `violating-repo` fixture, so no code change. Seat files: `_handoffs/handbook-157-review-20260908/seats/{opus,kimi,codex,qwen,gemini}-r1*.md`. Orchestrator's own verification (same matrix, before the seats): `verify-157.sh` — verbatim diff empty, selftest 192, make test 6/6, self-gate 1 pre-existing failure, 5+1 mutations red, 109 diff lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
